### PR TITLE
Add plan update and baseline state

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
       name="description"
       content="Interactive grilled meal prep calculator with macros and shopping list."
     />
-    <title>Grilled Meal Plan – 1,400 kcal/day</title>
+    <title>Prep Thy Meal</title>
     <link rel="icon" href="/favicon.ico" />
   </head>
   <body>

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,7 +1,19 @@
-import { collection, query, where, getDocs, addDoc, deleteDoc, doc } from 'firebase/firestore';
+import {
+  collection,
+  query,
+  where,
+  getDocs,
+  addDoc,
+  deleteDoc,
+  doc,
+  updateDoc,
+  setDoc,
+  getDoc,
+} from 'firebase/firestore';
 import { db } from './firebase.js';
 
 const plansRef = collection(db, 'plans');
+const settingsRef = collection(db, 'settings');
 
 export const loadPlans = async (uid) => {
   const q = query(plansRef, where('uid', '==', uid));
@@ -17,4 +29,19 @@ export const addPlan = async (uid, plan) => {
 export const removePlan = async (uid, id) => {
   await deleteDoc(doc(plansRef, id));
   return loadPlans(uid);
+};
+
+export const updatePlan = async (uid, id, plan) => {
+  await updateDoc(doc(plansRef, id), plan);
+  return loadPlans(uid);
+};
+
+export const loadBaseline = async (uid) => {
+  const docSnap = await getDoc(doc(settingsRef, uid));
+  return docSnap.exists() ? docSnap.data().baseline : null;
+};
+
+export const saveBaseline = async (uid, baseline) => {
+  await setDoc(doc(settingsRef, uid), { baseline }, { merge: true });
+  return loadBaseline(uid);
 };

--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -1,4 +1,11 @@
-import { loadPlans as apiLoad, addPlan as apiAdd, removePlan as apiRemove } from './api.js';
+import {
+  loadPlans as apiLoad,
+  addPlan as apiAdd,
+  removePlan as apiRemove,
+  updatePlan as apiUpdate,
+  loadBaseline as apiLoadBaseline,
+  saveBaseline as apiSaveBaseline,
+} from './api.js';
 
 export const loadPlans = async (uid) => {
   return apiLoad(uid);
@@ -10,4 +17,16 @@ export const addPlan = async (uid, plan) => {
 
 export const removePlan = async (uid, id) => {
   return apiRemove(uid, id);
+};
+
+export const updatePlan = async (uid, id, plan) => {
+  return apiUpdate(uid, id, plan);
+};
+
+export const loadBaseline = async (uid) => {
+  return apiLoadBaseline(uid);
+};
+
+export const saveBaseline = async (uid, baseline) => {
+  return apiSaveBaseline(uid, baseline);
 };


### PR DESCRIPTION
## Summary
- enable Firestore update operations and user baseline storage
- expose storage helpers for updating plans and saving/loading baseline
- load baseline on login and allow setting baseline from the UI
- allow updating existing plans when saving

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_687bf1037994832bb7c20b1836b15062