### PR TITLE
Implement SPA tabs and integrate instructions

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,12 @@
     />
     <title>Prep Thy Meal</title>
     <link rel="icon" href="/favicon.ico" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fredoka:wght@400;600&display=swap"
+      rel="stylesheet"
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Fredoka:wght@400;600&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Fredoka:wght@400;600&family=Inter:wght@400;600&display=swap"
       rel="stylesheet"
     />
   </head>

--- a/src/components/MealPrep.jsx
+++ b/src/components/MealPrep.jsx
@@ -1,11 +1,44 @@
 // src/components/MealPrep.jsx
-import React from "react";
+import React, { useState } from "react";
 import MealPrepCalculator from "./MealPrepCalculator";
+import MealPrepInstructions from "./MealPrepInstructions";
+
+const TABS = {
+  CALCULATOR: "calculator",
+  INSTRUCTIONS: "instructions",
+};
 
 const MealPrep = () => {
+  const [activeTab, setActiveTab] = useState(TABS.CALCULATOR);
+
   return (
-    <div>
-      <MealPrepCalculator />
+    <div className="app-container">
+      <nav className="nav-bar">
+        <button
+          className={
+            activeTab === TABS.CALCULATOR
+              ? "nav-button active"
+              : "nav-button"
+          }
+          onClick={() => setActiveTab(TABS.CALCULATOR)}
+        >
+          Calculator
+        </button>
+        <button
+          className={
+            activeTab === TABS.INSTRUCTIONS ? "nav-button active" : "nav-button"
+          }
+          onClick={() => setActiveTab(TABS.INSTRUCTIONS)}
+        >
+          Instructions
+        </button>
+      </nav>
+
+      {activeTab === TABS.CALCULATOR ? (
+        <MealPrepCalculator />
+      ) : (
+        <MealPrepInstructions />
+      )}
     </div>
   );
 };

--- a/src/components/MealPrep.jsx
+++ b/src/components/MealPrep.jsx
@@ -34,11 +34,13 @@ const MealPrep = () => {
         </button>
       </nav>
 
-      {activeTab === TABS.CALCULATOR ? (
-        <MealPrepCalculator />
-      ) : (
-        <MealPrepInstructions />
-      )}
+      <div key={activeTab} className="tab-content">
+        {activeTab === TABS.CALCULATOR ? (
+          <MealPrepCalculator />
+        ) : (
+          <MealPrepInstructions />
+        )}
+      </div>
     </div>
   );
 };

--- a/src/components/MealPrepCalculator.jsx
+++ b/src/components/MealPrepCalculator.jsx
@@ -36,6 +36,9 @@ const MealPrepCalculator = () => {
     defaultIngredients.map((ingredient) => ({ ...ingredient }))
   );
 
+  const [cheer, setCheer] = useState("");
+  const [showConfetti, setShowConfetti] = useState(false);
+
   // Saved plans
   const [savedPlans, setSavedPlans] = useState([]);
   const [planName, setPlanName] = useState("");
@@ -60,13 +63,16 @@ const MealPrepCalculator = () => {
   }, [user]);
 
   const updateIngredientAmount = (id, newGrams) => {
-    setIngredients(
-      ingredients.map((ingredient) =>
-        ingredient.id === id
-          ? { ...ingredient, grams: Math.max(0, newGrams) }
-          : ingredient
-      )
-    );
+    setIngredients((prev) => {
+      return prev.map((ingredient) => {
+        if (ingredient.id !== id) return ingredient;
+        if (ingredient.name === "Broccoli" && newGrams > ingredient.grams) {
+          setCheer("You broc my world!");
+          setTimeout(() => setCheer(""), 2000);
+        }
+        return { ...ingredient, grams: Math.max(0, newGrams) };
+      });
+    });
   };
 
   const handleSavePlan = async () => {
@@ -86,6 +92,8 @@ const MealPrepCalculator = () => {
     setSavedPlans(plans);
     setPlanName("");
     setCurrentPlanId(null);
+    setShowConfetti(true);
+    setTimeout(() => setShowConfetti(false), 2000);
   };
 
 const loadPlan = (id) => {
@@ -209,11 +217,13 @@ const loadPlan = (id) => {
 
   return (
     <div className="calculator">
+      {showConfetti && <div className="confetti">🎉🎉🎉</div>}
+      {cheer && <div className="cheer">{cheer}</div>}
       <div className="card">
         {/* Header */}
         <div className="center mb-8">
           <h1 className="text-4xl font-bold text-gray-800 mb-2">
-            🥗 Interactive Grilled Meal Plan
+            <span className="wiggle">🥗</span> Interactive Grilled Meal Plan
           </h1>
           <div className="flex items-center justify-center gap-2 mb-4">
             {editingTarget ? (
@@ -492,7 +502,7 @@ const loadPlan = (id) => {
                             }
                             className="text-red-600 hover:text-red-800 p-1 rounded"
                           >
-                            <Minus size={16} />
+                          <Minus size={16} className="wiggle" />
                           </button>
                           <input
                             type="number"
@@ -515,7 +525,7 @@ const loadPlan = (id) => {
                             }
                             className="text-green-600 hover:text-green-800 p-1 rounded"
                           >
-                            <Plus size={16} />
+                          <Plus size={16} className="wiggle" />
                           </button>
                         </div>
                       </td>

--- a/src/components/MealPrepCalculator.jsx
+++ b/src/components/MealPrepCalculator.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import { Plus, Minus, Edit2, Check, X } from "lucide-react";
 import jsPDF from "jspdf";
 import autoTable from "jspdf-autotable";
@@ -38,6 +38,7 @@ const MealPrepCalculator = () => {
 
   const [cheer, setCheer] = useState("");
   const [showConfetti, setShowConfetti] = useState(false);
+  const [goalConfetti, setGoalConfetti] = useState(false);
 
   // Saved plans
   const [savedPlans, setSavedPlans] = useState([]);
@@ -190,6 +191,29 @@ const loadPlan = (id) => {
     fat: Math.round((calorieTarget * (targetPercentages.fat / 100)) / 9),
   };
 
+  const progress = {
+    calories: Math.min(100, Math.round((dailyTotals.calories / calorieTarget) * 100)),
+    protein: Math.min(100, Math.round((dailyTotals.protein / targetMacros.protein) * 100)),
+    carbs: Math.min(100, Math.round((dailyTotals.carbs / targetMacros.carbs) * 100)),
+    fat: Math.min(100, Math.round((dailyTotals.fat / targetMacros.fat) * 100)),
+  };
+
+  const withinRange =
+    Math.abs(dailyTotals.calories - calorieTarget) <= 50 &&
+    Math.abs(dailyTotals.protein - targetMacros.protein) <= 10 &&
+    Math.abs(dailyTotals.carbs - targetMacros.carbs) <= 10 &&
+    Math.abs(dailyTotals.fat - targetMacros.fat) <= 5;
+
+  const lastRange = useRef(false);
+
+  useEffect(() => {
+    if (withinRange && !lastRange.current) {
+      setGoalConfetti(true);
+      setTimeout(() => setGoalConfetti(false), 1500);
+    }
+    lastRange.current = withinRange;
+  }, [withinRange]);
+
   const handleTargetEdit = () => {
     setCalorieTarget(tempTarget);
     setEditingTarget(false);
@@ -217,7 +241,9 @@ const loadPlan = (id) => {
 
   return (
     <div className="calculator">
-      {showConfetti && <div className="confetti">🎉🎉🎉</div>}
+      {(showConfetti || goalConfetti) && (
+        <div className="confetti">🎉🎉🎉</div>
+      )}
       {cheer && <div className="cheer">{cheer}</div>}
       <div className="card">
         {/* Header */}
@@ -615,70 +641,104 @@ const loadPlan = (id) => {
             <h3 className="text-xl font-bold text-gray-800 mb-4">
               Target Comparison
             </h3>
-            <div className="space-y-2">
-              <div className="flex justify-between">
-                <span className="font-medium">Calories:</span>
-                <span
-                  className={`font-bold ${
-                    Math.abs(dailyTotals.calories - calorieTarget) <= 50
-                      ? "text-green-600"
-                      : "text-red-600"
-                  }`}
-                >
-                  {calorieTarget} → {dailyTotals.calories}
-                </span>
+            <div className="space-y-4">
+              <div>
+                <div className="flex justify-between">
+                  <span className="font-medium">Calories:</span>
+                  <span
+                    className={`font-bold ${
+                      Math.abs(dailyTotals.calories - calorieTarget) <= 50
+                        ? "text-green-600"
+                        : "text-red-600"
+                    }`}
+                  >
+                    {calorieTarget} → {dailyTotals.calories}
+                  </span>
+                </div>
+                <div className="progress-wrapper mt-1">
+                  <div
+                    className="progress-bar"
+                    style={{ width: `${progress.calories}%` }}
+                  />
+                </div>
               </div>
-              <div className="flex justify-between">
-                <span className="font-medium">Protein:</span>
-                <span
-                  className={`font-bold ${
-                    Math.abs(dailyTotals.protein - targetMacros.protein) <= 10
-                      ? "text-green-600"
-                      : "text-red-600"
-                  }`}
-                >
-                  {targetMacros.protein}g ({targetPercentages.protein}%) →{" "}
-                  {dailyTotals.protein}g (
-                  {Math.round(
-                    ((dailyTotals.protein * 4) / dailyTotals.calories) * 100
-                  )}
-                  %)
-                </span>
+              <div>
+                <div className="flex justify-between">
+                  <span className="font-medium">Protein:</span>
+                  <span
+                    className={`font-bold ${
+                      Math.abs(dailyTotals.protein - targetMacros.protein) <= 10
+                        ? "text-green-600"
+                        : "text-red-600"
+                    }`}
+                  >
+                    {targetMacros.protein}g ({targetPercentages.protein}%) → {dailyTotals.protein}g (
+                    {Math.round(
+                      ((dailyTotals.protein * 4) / dailyTotals.calories) * 100
+                    )}
+                    %)
+                  </span>
+                </div>
+                <div className="progress-wrapper mt-1">
+                  <div
+                    className="progress-bar"
+                    style={{ width: `${progress.protein}%` }}
+                  />
+                </div>
               </div>
-              <div className="flex justify-between">
-                <span className="font-medium">Carbs:</span>
-                <span
-                  className={`font-bold ${
-                    Math.abs(dailyTotals.carbs - targetMacros.carbs) <= 10
-                      ? "text-green-600"
-                      : "text-red-600"
-                  }`}
-                >
-                  {targetMacros.carbs}g ({targetPercentages.carbs}%) →{" "}
-                  {dailyTotals.carbs}g (
-                  {Math.round(
-                    ((dailyTotals.carbs * 4) / dailyTotals.calories) * 100
-                  )}
-                  %)
-                </span>
+              <div>
+                <div className="flex justify-between">
+                  <span className="font-medium">Carbs:</span>
+                  <span
+                    className={`font-bold ${
+                      Math.abs(dailyTotals.carbs - targetMacros.carbs) <= 10
+                        ? "text-green-600"
+                        : "text-red-600"
+                    }`}
+                  >
+                    {targetMacros.carbs}g ({targetPercentages.carbs}%) → {dailyTotals.carbs}g (
+                    {Math.round(
+                      ((dailyTotals.carbs * 4) / dailyTotals.calories) * 100
+                    )}
+                    %)
+                  </span>
+                </div>
+                <div className="progress-wrapper mt-1">
+                  <div
+                    className="progress-bar"
+                    style={{ width: `${progress.carbs}%` }}
+                  />
+                </div>
               </div>
-              <div className="flex justify-between">
-                <span className="font-medium">Fat:</span>
-                <span
-                  className={`font-bold ${
-                    Math.abs(dailyTotals.fat - targetMacros.fat) <= 5
-                      ? "text-green-600"
-                      : "text-red-600"
-                  }`}
-                >
-                  {targetMacros.fat}g ({targetPercentages.fat}%) →{" "}
-                  {dailyTotals.fat}g (
-                  {Math.round(
-                    ((dailyTotals.fat * 9) / dailyTotals.calories) * 100
-                  )}
-                  %)
-                </span>
+              <div>
+                <div className="flex justify-between">
+                  <span className="font-medium">Fat:</span>
+                  <span
+                    className={`font-bold ${
+                      Math.abs(dailyTotals.fat - targetMacros.fat) <= 5
+                        ? "text-green-600"
+                        : "text-red-600"
+                    }`}
+                  >
+                    {targetMacros.fat}g ({targetPercentages.fat}%) → {dailyTotals.fat}g (
+                    {Math.round(
+                      ((dailyTotals.fat * 9) / dailyTotals.calories) * 100
+                    )}
+                    %)
+                  </span>
+                </div>
+                <div className="progress-wrapper mt-1">
+                  <div
+                    className="progress-bar"
+                    style={{ width: `${progress.fat}%` }}
+                  />
+                </div>
               </div>
+              {withinRange && (
+                <p className="text-center text-green-600 font-medium mt-2">
+                  You nailed today's targets! 👍
+                </p>
+              )}
             </div>
           </div>
         </div>

--- a/src/index.css
+++ b/src/index.css
@@ -5,6 +5,35 @@ body {
   color: #1f2937;
 }
 
+.app-container {
+  max-width: 64rem;
+  margin: 0 auto;
+  padding: 1.5rem;
+  min-height: 100vh;
+  background: linear-gradient(135deg, #f0fdf4, #eff6ff);
+}
+
+.nav-bar {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.nav-button {
+  background-color: #e5e7eb;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 0.375rem;
+  cursor: pointer;
+  color: #1f2937;
+}
+
+.nav-button.active,
+.nav-button:hover {
+  background-color: #c7d2fe;
+  color: #1e3a8a;
+}
+
 .calculator {
   max-width: 64rem;
   margin: 0 auto;

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,6 @@
 body {
   margin: 0;
-  font-family: system-ui, sans-serif;
+  font-family: "Fredoka", system-ui, sans-serif;
   background-color: #f9fafb;
   color: #1f2937;
 }
@@ -20,18 +20,21 @@ body {
 }
 
 .nav-button {
-  background-color: #e5e7eb;
+  background: linear-gradient(135deg, #fef3c7, #fde68a);
   border: none;
   padding: 0.5rem 1rem;
-  border-radius: 0.375rem;
+  border-radius: 9999px;
   cursor: pointer;
   color: #1f2937;
+  font-weight: 600;
+  transition: transform 0.1s;
 }
 
 .nav-button.active,
 .nav-button:hover {
-  background-color: #c7d2fe;
+  background: linear-gradient(135deg, #bfdbfe, #c7d2fe);
   color: #1e3a8a;
+  transform: scale(1.05);
 }
 
 .calculator {
@@ -335,4 +338,50 @@ input[type="number"] {
 }
 .md\:grid-cols-2 {
   grid-template-columns: repeat(2, 1fr);
+}
+
+@keyframes wiggle {
+  0%, 100% {
+    transform: rotate(0deg);
+  }
+  50% {
+    transform: rotate(15deg);
+  }
+}
+
+.wiggle:hover {
+  animation: wiggle 0.5s ease-in-out;
+}
+
+@keyframes confetti {
+  0% {
+    opacity: 1;
+    transform: translate(-50%, 0);
+  }
+  100% {
+    opacity: 0;
+    transform: translate(-50%, -100%);
+  }
+}
+
+.confetti {
+  position: fixed;
+  top: 20%;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 3rem;
+  pointer-events: none;
+  animation: confetti 2s forwards;
+}
+
+.cheer {
+  position: fixed;
+  top: 1rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background-color: #fef08a;
+  color: #854d0e;
+  padding: 0.5rem 1rem;
+  border-radius: 9999px;
+  animation: confetti 2s forwards;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,8 +1,14 @@
 body {
   margin: 0;
-  font-family: "Fredoka", system-ui, sans-serif;
-  background-color: #f9fafb;
+  font-family: "Inter", system-ui, sans-serif;
+  background-color: #f8fafc;
   color: #1f2937;
+}
+
+h1,
+h2,
+h3 {
+  font-family: "Fredoka", sans-serif;
 }
 
 .app-container {
@@ -20,7 +26,7 @@ body {
 }
 
 .nav-button {
-  background: linear-gradient(135deg, #fef3c7, #fde68a);
+  background: linear-gradient(135deg, #dbeafe, #bae6fd);
   border: none;
   padding: 0.5rem 1rem;
   border-radius: 9999px;
@@ -374,6 +380,21 @@ input[type="number"] {
   animation: confetti 2s forwards;
 }
 
+.tab-content {
+  animation: slideIn 0.3s ease;
+}
+
+@keyframes slideIn {
+  from {
+    opacity: 0;
+    transform: translateX(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
 .cheer {
   position: fixed;
   top: 1rem;
@@ -384,4 +405,16 @@ input[type="number"] {
   padding: 0.5rem 1rem;
   border-radius: 9999px;
   animation: confetti 2s forwards;
+}
+
+.progress-wrapper {
+  background-color: #e5e7eb;
+  border-radius: 0.5rem;
+  overflow: hidden;
+  height: 0.5rem;
+}
+
+.progress-bar {
+  height: 100%;
+  background: linear-gradient(to right, #a5b4fc, #38bdf8);
 }


### PR DESCRIPTION
## Summary
- add tab-based navigation to display calculator or instructions
- style new navigation and apply background gradient to new container
- keep existing calculator look and feel

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687bfc74d3a8832b8df1879141a225ef