### PR TITLE
Add firebase ingredient sync and PDF improvements

### DIFF
--- a/src/components/MealPrep.jsx
+++ b/src/components/MealPrep.jsx
@@ -1,9 +1,11 @@
 // src/components/MealPrep.jsx
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import MealPrepCalculator from "./MealPrepCalculator";
 import MealPrepInstructions from "./MealPrepInstructions";
 import IngredientManager from "./IngredientManager";
 import { getAllBaseIngredients } from "../utils/nutritionHelpers";
+import { syncFromRemote } from "../utils/ingredientStorage";
+import { useUser } from "../context/UserContext.jsx";
 
 const TABS = {
   CALCULATOR: "calculator",
@@ -12,12 +14,23 @@ const TABS = {
 };
 
 const MealPrep = () => {
+  const { user } = useUser();
   const [activeTab, setActiveTab] = useState(TABS.CALCULATOR);
   const [allIngredients, setAllIngredients] = useState(getAllBaseIngredients());
 
   const handleIngredientChange = (list) => {
     setAllIngredients(list);
   };
+
+  useEffect(() => {
+    if (user) {
+      syncFromRemote(user.uid).then(() =>
+        setAllIngredients(getAllBaseIngredients())
+      );
+    } else {
+      setAllIngredients(getAllBaseIngredients());
+    }
+  }, [user]);
 
   return (
     <div className="app-container">

--- a/src/components/MealPrepCalculator.jsx
+++ b/src/components/MealPrepCalculator.jsx
@@ -61,20 +61,24 @@ const MealPrepCalculator = ({ allIngredients }) => {
       setTargetPercentages(basePerc);
       setTempPercentages(basePerc);
       setIngredients(
-        allIngredients.map((ingredient) => {
-          const saved = baseline.ingredients.find((i) => i.id === ingredient.id);
-          return saved ? { ...ingredient, grams: saved.grams } : { ...ingredient };
-        })
+        baseline.ingredients
+          .map(({ id, grams }) => {
+            const base = allIngredients.find((ing) => ing.id === id);
+            return base ? { ...base, grams } : null;
+          })
+          .filter(Boolean)
       );
     });
   }, [user, allIngredients]);
 
   useEffect(() => {
     setIngredients((prev) =>
-      allIngredients.map((ing) => {
-        const existing = prev.find((p) => p.id === ing.id);
-        return existing ? { ...existing, ...ing } : { ...ing };
-      })
+      prev
+        .map((ing) => {
+          const updated = allIngredients.find((i) => i.id === ing.id);
+          return updated ? { ...updated, grams: ing.grams } : ing;
+        })
+        .filter(Boolean)
     );
   }, [allIngredients]);
 
@@ -143,12 +147,12 @@ const loadPlan = (id) => {
   setTargetPercentages(planPerc);
   setTempPercentages(planPerc);
   setIngredients(
-    allIngredients.map((ingredient) => {
-      const saved = plan.ingredients.find((i) => i.id === ingredient.id);
-      return saved
-        ? { ...ingredient, grams: saved.grams }
-        : { ...ingredient };
-    })
+    plan.ingredients
+      .map(({ id, grams }) => {
+        const base = allIngredients.find((i) => i.id === id);
+        return base ? { ...base, grams } : null;
+      })
+      .filter(Boolean)
   );
 };
 

--- a/src/components/MealPrepCalculator.jsx
+++ b/src/components/MealPrepCalculator.jsx
@@ -182,6 +182,42 @@ const loadPlan = (id) => {
       body: rows,
       startY: 35,
     });
+    autoTable(doc, {
+      head: [["Daily Totals", "Calories", "Protein", "Carbs", "Fat"]],
+      body: [["", dailyTotals.calories, dailyTotals.protein, dailyTotals.carbs, dailyTotals.fat]],
+      startY: doc.lastAutoTable.finalY + 5,
+    });
+
+    autoTable(doc, {
+      head: [["Target", "Actual", "Difference"]],
+      body: [
+        [
+          "Calories",
+          calorieTarget,
+          dailyTotals.calories,
+          dailyTotals.calories - calorieTarget,
+        ],
+        [
+          "Protein (g)",
+          targetMacros.protein,
+          dailyTotals.protein,
+          (dailyTotals.protein - targetMacros.protein).toFixed(1),
+        ],
+        [
+          "Carbs (g)",
+          targetMacros.carbs,
+          dailyTotals.carbs,
+          (dailyTotals.carbs - targetMacros.carbs).toFixed(1),
+        ],
+        [
+          "Fat (g)",
+          targetMacros.fat,
+          dailyTotals.fat,
+          (dailyTotals.fat - targetMacros.fat).toFixed(1),
+        ],
+      ],
+      startY: doc.lastAutoTable.finalY + 5,
+    });
 
     doc.save(`${title.replace(/\s+/g, "_").toLowerCase()}.pdf`);
   };

--- a/src/components/MealPrepCalculator.jsx
+++ b/src/components/MealPrepCalculator.jsx
@@ -219,6 +219,16 @@ const loadPlan = (id) => {
       startY: doc.lastAutoTable.finalY + 5,
     });
 
+    autoTable(doc, {
+      head: [["Shopping List (6 days)", "Grams", "Pounds"]],
+      body: ingredients.map((ing) => {
+        const totalGrams = ing.grams * 12;
+        const pounds = (totalGrams / 453.592).toFixed(2);
+        return [ing.name, totalGrams, pounds];
+      }),
+      startY: doc.lastAutoTable.finalY + 5,
+    });
+
     doc.save(`${title.replace(/\s+/g, "_").toLowerCase()}.pdf`);
   };
 

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -45,3 +45,14 @@ export const saveBaseline = async (uid, baseline) => {
   await setDoc(doc(settingsRef, uid), { baseline }, { merge: true });
   return loadBaseline(uid);
 };
+
+// Custom Ingredients
+export const loadCustomIngredients = async (uid) => {
+  const snap = await getDoc(doc(settingsRef, uid));
+  return snap.exists() ? snap.data().customIngredients || [] : [];
+};
+
+export const saveCustomIngredients = async (uid, items) => {
+  await setDoc(doc(settingsRef, uid), { customIngredients: items }, { merge: true });
+  return loadCustomIngredients(uid);
+};


### PR DESCRIPTION
## Summary
- sync custom ingredients with Firebase user profile
- load user ingredients when user logs in
- enhance PDF export with daily totals and target comparison

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: blocked by network)*

------
https://chatgpt.com/codex/tasks/task_e_687ea523b870832ba74abc2daa369479