### PR TITLE
Add meal buckets with matching option

### DIFF
--- a/src/components/MealPrepCalculator.jsx
+++ b/src/components/MealPrepCalculator.jsx
@@ -32,7 +32,6 @@ const MealPrepCalculator = ({ allIngredients }) => {
   });
 
   const MEALS = ["breakfast", "lunch", "dinner", "snack"];
-  const [activeMeal, setActiveMeal] = useState("lunch");
   const [matchDinner, setMatchDinner] = useState(false);
   const [mealIngredients, setMealIngredients] = useState({
     breakfast: [],
@@ -620,7 +619,7 @@ const loadPlan = (id) => {
         {/* Instructions */}
         <div className="panel-yellow mb-6">
           <p className="text-sm text-yellow-800">
-            <strong>Instructions:</strong> Add foods to each meal. Select "Match
+            <strong>Instructions:</strong> Add foods to each meal. Use "Lunch =
             Dinner" if lunch and dinner are identical. All weights are raw and
             grilled unless noted.
           </p>
@@ -632,37 +631,23 @@ const loadPlan = (id) => {
             Per Meal (Raw Weights)
           </h2>
           <div className="flex gap-4 mb-4">
-            {MEALS.map((meal) => (
-              <label key={meal} className="flex items-center gap-1">
-                <input
-                  type="radio"
-                  name="meal"
-                  value={meal}
-                  checked={activeMeal === meal}
-                  onChange={() => setActiveMeal(meal)}
-                />
-                <span className="capitalize">{meal}</span>
-              </label>
-            ))}
-            {activeMeal === "lunch" && (
-              <label className="flex items-center gap-1 ml-4">
-                <input
-                  type="checkbox"
-                  checked={matchDinner}
-                  onChange={(e) => {
-                    const checked = e.target.checked;
-                    setMatchDinner(checked);
-                    if (checked) {
-                      setMealIngredients((prev) => ({
-                        ...prev,
-                        dinner: prev.lunch.map((i) => ({ ...i })),
-                      }));
-                    }
-                  }}
-                />
-                <span>Match Dinner</span>
-              </label>
-            )}
+            <label className="flex items-center gap-1">
+              <input
+                type="checkbox"
+                checked={matchDinner}
+                onChange={(e) => {
+                  const checked = e.target.checked;
+                  setMatchDinner(checked);
+                  if (checked) {
+                    setMealIngredients((prev) => ({
+                      ...prev,
+                      dinner: prev.lunch.map((i) => ({ ...i })),
+                    }));
+                  }
+                }}
+              />
+              <span>Lunch = Dinner</span>
+            </label>
           </div>
 
           {MEALS.map((meal) => {
@@ -671,19 +656,11 @@ const loadPlan = (id) => {
                 ? mealIngredients.lunch
                 : mealIngredients[meal];
             return (
-              <details
-                key={meal}
-                open={activeMeal === meal}
-                className="mb-4 border rounded"
-              >
-                <summary
-                  onClick={() => setActiveMeal(meal)}
-                  className="cursor-pointer select-none capitalize font-semibold bg-gray-100 p-2"
-                >
+              <details key={meal} open className="mb-4 border rounded">
+                <summary className="cursor-pointer select-none capitalize font-semibold bg-gray-100 p-2">
                   {meal}
                 </summary>
-                {activeMeal === meal && (
-                  <div className="p-2">
+                <div className="p-2">
                     <div className="flex items-center gap-2 mb-2">
                       <select
                         value={selectedId}
@@ -813,7 +790,6 @@ const loadPlan = (id) => {
                       </table>
                     </div>
                   </div>
-                )}
               </details>
             );
           })}

--- a/src/components/MealPrepCalculator.jsx
+++ b/src/components/MealPrepCalculator.jsx
@@ -41,10 +41,6 @@ const MealPrepCalculator = ({ allIngredients }) => {
     snack: [],
   });
   const [selectedId, setSelectedId] = useState("");
-  const ingredients =
-    activeMeal === "dinner" && matchDinner
-      ? mealIngredients.lunch
-      : mealIngredients[activeMeal];
 
   const [cheer, setCheer] = useState("");
   const [showConfetti, setShowConfetti] = useState(false);
@@ -129,14 +125,14 @@ const MealPrepCalculator = ({ allIngredients }) => {
     });
   };
 
-  const handleAddIngredient = () => {
+  const handleAddIngredient = (meal) => {
     const id = parseInt(selectedId);
     const item = allIngredients.find((i) => i.id === id);
     if (!item) return;
     setMealIngredients((prev) => {
-      const list = [...prev[activeMeal], { ...item }];
-      const updated = { ...prev, [activeMeal]: list };
-      if (activeMeal === "lunch" && matchDinner) {
+      const list = [...prev[meal], { ...item }];
+      const updated = { ...prev, [meal]: list };
+      if (meal === "lunch" && matchDinner) {
         updated.dinner = list.map((i) => ({ ...i }));
       }
       return updated;
@@ -321,13 +317,6 @@ const loadPlan = (id) => {
       { calories: 0, protein: 0, carbs: 0, fat: 0 }
     );
 
-  const currentList =
-    activeMeal === "dinner" && matchDinner
-      ? mealIngredients.lunch
-      : mealIngredients[activeMeal];
-
-  // Totals for the displayed meal
-  const mealTotals = calcTotals(currentList);
 
   // Daily totals across all meals
   const dailyTotals = MEALS.reduce(
@@ -642,7 +631,7 @@ const loadPlan = (id) => {
           <h2 className="text-2xl font-bold text-gray-800 mb-4">
             Per Meal (Raw Weights)
           </h2>
-          <div className="flex gap-4 mb-2">
+          <div className="flex gap-4 mb-4">
             {MEALS.map((meal) => (
               <label key={meal} className="flex items-center gap-1">
                 <input
@@ -675,144 +664,159 @@ const loadPlan = (id) => {
               </label>
             )}
           </div>
-          <div className="flex items-center gap-2 mb-2">
-            <select
-              value={selectedId}
-              onChange={(e) => setSelectedId(e.target.value)}
-              className="border px-2 py-1"
-            >
-              <option value="">Select ingredient</option>
-              {allIngredients
-                .filter((i) => !ingredients.some((p) => p.id === i.id))
-                .map((i) => (
-                  <option key={i.id} value={i.id}>
-                    {i.name}
-                  </option>
-                ))}
-            </select>
-            <button className="btn-green" onClick={handleAddIngredient}
-              disabled={!selectedId}
-            >
-              Add
-            </button>
-          </div>
-          <div className="overflow-x-auto">
-            <table className="min-w-max w-full border-collapse border border-gray-300 rounded-lg">
-              <thead>
-                <tr className="bg-gray-100">
-                  <th className="border border-gray-300 p-3 text-left">
-                    Ingredient
-                  </th>
-                  <th className="border border-gray-300 p-3 text-center">
-                    Grams
-                  </th>
-                  <th className="border border-gray-300 p-3 text-center">
-                    Calories
-                  </th>
-                  <th className="border border-gray-300 p-3 text-center">
-                    Protein (g)
-                  </th>
-                  <th className="border border-gray-300 p-3 text-center">
-                    Carbs (g)
-                  </th>
-                  <th className="border border-gray-300 p-3 text-center">
-                    Fat (g)
-                  </th>
-                  <th className="border border-gray-300 p-3 text-center">-</th>
-                </tr>
-              </thead>
-              <tbody>
-                {ingredients.map((ingredient) => {
-                  const nutrition = calculateNutrition(ingredient);
-                  return (
-                    <tr key={ingredient.id} className="hover:bg-gray-50">
-                      <td className="border border-gray-300 p-3 font-medium capitalize">
-                        {ingredient.name}
-                      </td>
-                      <td className="border border-gray-300 p-3">
-                        <div className="flex items-center justify-center gap-2">
-                          <button
-                            onClick={() =>
-                              updateIngredientAmount(
-                                activeMeal,
-                                ingredient.id,
-                                ingredient.grams - 5
-                              )
-                            }
-                            className="text-red-600 hover:text-red-800 p-1 rounded"
-                          >
-                          <Minus size={16} className="wiggle" />
-                          </button>
-                          <input
-                            type="number"
-                            value={ingredient.grams}
-                            onChange={(e) =>
-                              updateIngredientAmount(
-                                activeMeal,
-                                ingredient.id,
-                                parseInt(e.target.value) || 0
-                              )
-                            }
-                            className="w-16 px-2 py-1 border border-gray-300 rounded text-center"
-                            min="0"
-                          />
-                          <button
-                            onClick={() =>
-                              updateIngredientAmount(
-                                activeMeal,
-                                ingredient.id,
-                                ingredient.grams + 5
-                              )
-                            }
-                            className="text-green-600 hover:text-green-800 p-1 rounded"
-                          >
-                          <Plus size={16} className="wiggle" />
-                          </button>
-                        </div>
-                      </td>
-                      <td className="border border-gray-300 p-3 text-center">
-                        {nutrition.calories}
-                      </td>
-                      <td className="border border-gray-300 p-3 text-center">
-                        {nutrition.protein}
-                      </td>
-                      <td className="border border-gray-300 p-3 text-center">
-                        {nutrition.carbs}
-                      </td>
-                      <td className="border border-gray-300 p-3 text-center">
-                        {nutrition.fat}
-                      </td>
-                      <td className="border border-gray-300 p-3 text-center">
-                        <button
-                          className="text-red-600"
-                          onClick={() => removeIngredient(activeMeal, ingredient.id)}
-                        >
-                          x
-                        </button>
-                      </td>
-                    </tr>
-                  );
-                })}
-                <tr className="bg-blue-50 font-bold">
-                  <td className="border border-gray-300 p-3">Total/meal</td>
-                  <td className="border border-gray-300 p-3 text-center">—</td>
-                  <td className="border border-gray-300 p-3 text-center">
-                    {Math.round(mealTotals.calories)}
-                  </td>
-                  <td className="border border-gray-300 p-3 text-center">
-                    {Math.round(mealTotals.protein * 10) / 10}
-                  </td>
-                  <td className="border border-gray-300 p-3 text-center">
-                    {Math.round(mealTotals.carbs * 10) / 10}
-                  </td>
-                  <td className="border border-gray-300 p-3 text-center">
-                    {Math.round(mealTotals.fat * 10) / 10}
-                  </td>
-                  <td className="border border-gray-300 p-3 text-center">-</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
+
+          {MEALS.map((meal) => {
+            const list =
+              meal === "dinner" && matchDinner
+                ? mealIngredients.lunch
+                : mealIngredients[meal];
+            return (
+              <details
+                key={meal}
+                open={activeMeal === meal}
+                className="mb-4 border rounded"
+              >
+                <summary
+                  onClick={() => setActiveMeal(meal)}
+                  className="cursor-pointer select-none capitalize font-semibold bg-gray-100 p-2"
+                >
+                  {meal}
+                </summary>
+                {activeMeal === meal && (
+                  <div className="p-2">
+                    <div className="flex items-center gap-2 mb-2">
+                      <select
+                        value={selectedId}
+                        onChange={(e) => setSelectedId(e.target.value)}
+                        className="border px-2 py-1"
+                      >
+                        <option value="">Select ingredient</option>
+                        {allIngredients
+                          .filter((i) => !list.some((p) => p.id === i.id))
+                          .map((i) => (
+                            <option key={i.id} value={i.id}>
+                              {i.name}
+                            </option>
+                          ))}
+                      </select>
+                      <button
+                        className="btn-green"
+                        onClick={() => handleAddIngredient(meal)}
+                        disabled={!selectedId}
+                      >
+                        Add
+                      </button>
+                    </div>
+                    <div className="overflow-x-auto">
+                      <table className="min-w-max w-full border-collapse border border-gray-300 rounded-lg">
+                        <thead>
+                          <tr className="bg-gray-100">
+                            <th className="border border-gray-300 p-3 text-left">Ingredient</th>
+                            <th className="border border-gray-300 p-3 text-center">Grams</th>
+                            <th className="border border-gray-300 p-3 text-center">Calories</th>
+                            <th className="border border-gray-300 p-3 text-center">Protein (g)</th>
+                            <th className="border border-gray-300 p-3 text-center">Carbs (g)</th>
+                            <th className="border border-gray-300 p-3 text-center">Fat (g)</th>
+                            <th className="border border-gray-300 p-3 text-center">-</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {list.map((ingredient) => {
+                            const nutrition = calculateNutrition(ingredient);
+                            return (
+                              <tr key={ingredient.id} className="hover:bg-gray-50">
+                                <td className="border border-gray-300 p-3 font-medium capitalize">
+                                  {ingredient.name}
+                                </td>
+                                <td className="border border-gray-300 p-3">
+                                  <div className="flex items-center justify-center gap-2">
+                                    <button
+                                      onClick={() =>
+                                        updateIngredientAmount(
+                                          meal,
+                                          ingredient.id,
+                                          ingredient.grams - 5
+                                        )
+                                      }
+                                      className="text-red-600 hover:text-red-800 p-1 rounded"
+                                    >
+                                      <Minus size={16} className="wiggle" />
+                                    </button>
+                                    <input
+                                      type="number"
+                                      value={ingredient.grams}
+                                      onChange={(e) =>
+                                        updateIngredientAmount(
+                                          meal,
+                                          ingredient.id,
+                                          parseInt(e.target.value) || 0
+                                        )
+                                      }
+                                      className="w-16 px-2 py-1 border border-gray-300 rounded text-center"
+                                      min="0"
+                                    />
+                                    <button
+                                      onClick={() =>
+                                        updateIngredientAmount(
+                                          meal,
+                                          ingredient.id,
+                                          ingredient.grams + 5
+                                        )
+                                      }
+                                      className="text-green-600 hover:text-green-800 p-1 rounded"
+                                    >
+                                      <Plus size={16} className="wiggle" />
+                                    </button>
+                                  </div>
+                                </td>
+                                <td className="border border-gray-300 p-3 text-center">
+                                  {nutrition.calories}
+                                </td>
+                                <td className="border border-gray-300 p-3 text-center">
+                                  {nutrition.protein}
+                                </td>
+                                <td className="border border-gray-300 p-3 text-center">
+                                  {nutrition.carbs}
+                                </td>
+                                <td className="border border-gray-300 p-3 text-center">
+                                  {nutrition.fat}
+                                </td>
+                                <td className="border border-gray-300 p-3 text-center">
+                                  <button
+                                    className="text-red-600"
+                                    onClick={() => removeIngredient(meal, ingredient.id)}
+                                  >
+                                    x
+                                  </button>
+                                </td>
+                              </tr>
+                            );
+                          })}
+                          <tr className="bg-blue-50 font-bold">
+                            <td className="border border-gray-300 p-3">Total/meal</td>
+                            <td className="border border-gray-300 p-3 text-center">—</td>
+                            <td className="border border-gray-300 p-3 text-center">
+                              {Math.round(calcTotals(list).calories)}
+                            </td>
+                            <td className="border border-gray-300 p-3 text-center">
+                              {Math.round(calcTotals(list).protein * 10) / 10}
+                            </td>
+                            <td className="border border-gray-300 p-3 text-center">
+                              {Math.round(calcTotals(list).carbs * 10) / 10}
+                            </td>
+                            <td className="border border-gray-300 p-3 text-center">
+                              {Math.round(calcTotals(list).fat * 10) / 10}
+                            </td>
+                            <td className="border border-gray-300 p-3 text-center">-</td>
+                          </tr>
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
+                )}
+              </details>
+            );
+          })}
         </div>
 
         {/* Daily Totals */}

--- a/src/components/MealPrepCalculator.jsx
+++ b/src/components/MealPrepCalculator.jsx
@@ -211,10 +211,7 @@ const loadPlan = (id) => {
     );
 
     const rows = MEALS.flatMap((meal) => {
-      const list =
-        meal === "dinner" && matchDinner
-          ? mealIngredients.lunch
-          : mealIngredients[meal];
+      const list = mealIngredients[meal];
       return list.map((ing) => {
         const n = calculateNutrition(ing);
         return [
@@ -315,10 +312,7 @@ const loadPlan = (id) => {
   // Daily totals across all meals
   const dailyTotals = MEALS.reduce(
     (totals, meal) => {
-      const list =
-        meal === "dinner" && matchDinner
-          ? mealIngredients.lunch
-          : mealIngredients[meal];
+      const list = mealIngredients[meal];
       const t = calcTotals(list);
       return {
         calories: totals.calories + t.calories,
@@ -337,10 +331,7 @@ const loadPlan = (id) => {
   const aggregatedIngredients = React.useMemo(() => {
     const totals = {};
     MEALS.forEach((meal) => {
-      const list =
-        meal === "dinner" && matchDinner
-          ? mealIngredients.lunch
-          : mealIngredients[meal];
+      const list = mealIngredients[meal];
       list.forEach((ing) => {
         if (!totals[ing.id]) {
           totals[ing.id] = { ...ing, grams: ing.grams };
@@ -350,7 +341,7 @@ const loadPlan = (id) => {
       });
     });
     return Object.values(totals);
-  }, [mealIngredients, matchDinner]);
+  }, [mealIngredients]);
 
   // Calculate target macros based on calorie target and percentages
   const targetMacros = {
@@ -664,10 +655,7 @@ const loadPlan = (id) => {
           </div>
 
           {MEALS.map((meal) => {
-            const list =
-              meal === "dinner" && matchDinner
-                ? mealIngredients.lunch
-                : mealIngredients[meal];
+            const list = mealIngredients[meal];
             return (
               <details key={meal} open className="mb-4 border rounded">
                 <summary className="cursor-pointer select-none capitalize font-semibold bg-gray-100 p-2">

--- a/src/components/MealPrepCalculator.jsx
+++ b/src/components/MealPrepCalculator.jsx
@@ -656,8 +656,13 @@ const loadPlan = (id) => {
 
           {MEALS.map((meal) => {
             const list = mealIngredients[meal];
+            const disabled = matchDinner && meal === "dinner";
             return (
-              <details key={meal} open className="mb-4 border rounded">
+              <details
+                key={meal}
+                open
+                className={`mb-4 border rounded ${disabled ? "disabled-section" : ""}`}
+              >
                 <summary className="cursor-pointer select-none capitalize font-semibold bg-gray-100 p-2">
                   {meal}
                 </summary>
@@ -667,6 +672,7 @@ const loadPlan = (id) => {
                         value={selectedId}
                         onChange={(e) => setSelectedId(e.target.value)}
                         className="border px-2 py-1"
+                        disabled={disabled}
                       >
                         <option value="">Select ingredient</option>
                         {allIngredients
@@ -680,7 +686,7 @@ const loadPlan = (id) => {
                       <button
                         className="btn-green"
                         onClick={() => handleAddIngredient(meal)}
-                        disabled={!selectedId}
+                        disabled={!selectedId || disabled}
                       >
                         Add
                       </button>
@@ -701,6 +707,7 @@ const loadPlan = (id) => {
                         <tbody>
                           {list.map((ingredient) => {
                             const nutrition = calculateNutrition(ingredient);
+                            const disabled = matchDinner && meal === "dinner";
                             return (
                               <tr key={ingredient.id} className="hover:bg-gray-50">
                                 <td className="border border-gray-300 p-3 font-medium capitalize">
@@ -717,6 +724,7 @@ const loadPlan = (id) => {
                                         )
                                       }
                                       className="text-red-600 hover:text-red-800 p-1 rounded"
+                                      disabled={disabled}
                                     >
                                       <Minus size={16} className="wiggle" />
                                     </button>
@@ -732,6 +740,7 @@ const loadPlan = (id) => {
                                       }
                                       className="w-16 px-2 py-1 border border-gray-300 rounded text-center"
                                       min="0"
+                                      disabled={disabled}
                                     />
                                     <button
                                       onClick={() =>
@@ -742,6 +751,7 @@ const loadPlan = (id) => {
                                         )
                                       }
                                       className="text-green-600 hover:text-green-800 p-1 rounded"
+                                      disabled={disabled}
                                     >
                                       <Plus size={16} className="wiggle" />
                                     </button>
@@ -763,6 +773,7 @@ const loadPlan = (id) => {
                                   <button
                                     className="text-red-600"
                                     onClick={() => removeIngredient(meal, ingredient.id)}
+                                    disabled={disabled}
                                   >
                                     x
                                   </button>

--- a/src/index.css
+++ b/src/index.css
@@ -278,6 +278,11 @@ input[type="number"] {
   padding: 1.5rem;
 }
 
+.disabled-section {
+  opacity: 0.5;
+  pointer-events: none;
+}
+
 .border {
   border: 1px solid #d1d5db;
 }

--- a/src/utils/nutritionHelpers.js
+++ b/src/utils/nutritionHelpers.js
@@ -1,8 +1,17 @@
 // src/utils/nutritionHelpers.js
 import { loadCustomIngredients } from "./ingredientStorage";
 
+export const normalizeIngredient = (item) => ({
+  ...item,
+  grams: Number(item.grams) || 0,
+  calories: Number(item.calories) || 0,
+  protein: Number(item.protein) || 0,
+  carbs: Number(item.carbs) || 0,
+  fat: Number(item.fat) || 0,
+});
+
 export const getAllBaseIngredients = () => {
-  return loadCustomIngredients();
+  return loadCustomIngredients().map(normalizeIngredient);
 };
 
 const getOriginal = (id) => {


### PR DESCRIPTION
## Summary
- allow selecting breakfast, lunch, dinner or snack
- optional lunch and dinner matching
- compute totals across all meals
- update shopping list and export to include all meals

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68803a034b10832bb782df26daaf1e43