### PR TITLE
feat: multi-theme system with custom theme builder

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Fredoka:wght@400;600&family=Inter:wght@400;600&family=Urbanist:wght@400;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;600;700&family=IBM+Plex+Sans:wght@400;600;700&family=Inter:wght@400;600;700&family=Lato:wght@400;600;700&family=Merriweather+Sans:wght@400;600;700&family=Nunito:wght@400;600;700&family=Orbitron:wght@700;900&family=Poppins:wght@400;600;700&family=Space+Grotesk:wght@400;600;700&family=Urbanist:wght@400;600;700&display=swap"
       rel="stylesheet"
     />
   </head>

--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -1,5 +1,5 @@
 // src/app/App.jsx
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useEffect, useRef, useMemo } from 'react';
 import { Box } from '@mui/material';
 import { Toaster } from 'react-hot-toast';
 import toast from 'react-hot-toast';
@@ -12,6 +12,42 @@ import ErrorBoundary from '../shared/components/ui/ErrorBoundary';
 import OfflineBanner from '../shared/components/layout/OfflineBanner';
 import OnboardingModal from '../shared/components/onboarding/OnboardingModal';
 import { hasCompletedOnboarding, completeOnboarding } from '../shared/services/onboarding';
+import { useUser } from '../features/auth/UserContext';
+import { loadUserPreferences, updateUserPreference } from '../shared/services/userPreferences';
+
+const ThemeSync = () => {
+  const { user } = useUser();
+  const { themeName, isDark, customConfig, setThemeName, setIsDark, setCustomConfig } = useAppTheme();
+  const hasLoadedRef = useRef(false);
+
+  // Load from Firebase on login (once per session)
+  useEffect(() => {
+    if (user?.uid && !hasLoadedRef.current) {
+      hasLoadedRef.current = true;
+      loadUserPreferences(user.uid).then(prefs => {
+        if (prefs.themePrefs) {
+          setThemeName(prefs.themePrefs.themeName);
+          setIsDark(prefs.themePrefs.isDark);
+          if (prefs.themePrefs.customConfig) {
+            setCustomConfig(prefs.themePrefs.customConfig);
+          }
+        }
+      });
+    }
+  }, [user?.uid]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Save to Firebase on change (debounced, skip initial load)
+  useEffect(() => {
+    if (user?.uid && hasLoadedRef.current) {
+      const timer = setTimeout(() => {
+        updateUserPreference(user.uid, 'themePrefs', { themeName, isDark, customConfig });
+      }, 1000);
+      return () => clearTimeout(timer);
+    }
+  }, [user?.uid, themeName, isDark, customConfig]);
+
+  return null;
+};
 
 const AppContent = () => {
   const [showOnboarding, setShowOnboarding] = useState(false);
@@ -51,34 +87,37 @@ const AppContent = () => {
   }, []); // No dependencies - run once on mount
 
   return (
-    <Box
-      component="main"
-      sx={(theme) => ({
-        minHeight: '100vh',
-        bgcolor: 'background.default',
-        color: 'text.primary',
-        transition: theme.transitions.create('background-color', {
-          duration: theme.transitions.duration.standard,
-        }),
-      })}
-    >
-      <OfflineBanner />
-      <ErrorBoundary message="An error occurred in the meal planning app. Please try refreshing the page.">
-        <MealPrep />
-      </ErrorBoundary>
-      <OnboardingModal
-        isOpen={showOnboarding}
-        onComplete={() => {
-          completeOnboarding();
-          setShowOnboarding(false);
-          toast.success("Welcome! Let's start planning your meals.");
-        }}
-      />
-      <Toaster
-        position="top-center"
-        toastOptions={toastOptions}
-      />
-    </Box>
+    <>
+      <ThemeSync />
+      <Box
+        component="main"
+        sx={(theme) => ({
+          minHeight: '100vh',
+          bgcolor: 'background.default',
+          color: 'text.primary',
+          transition: theme.transitions.create('background-color', {
+            duration: theme.transitions.duration.standard,
+          }),
+        })}
+      >
+        <OfflineBanner />
+        <ErrorBoundary message="An error occurred in the meal planning app. Please try refreshing the page.">
+          <MealPrep />
+        </ErrorBoundary>
+        <OnboardingModal
+          isOpen={showOnboarding}
+          onComplete={() => {
+            completeOnboarding();
+            setShowOnboarding(false);
+            toast.success("Welcome! Let's start planning your meals.");
+          }}
+        />
+        <Toaster
+          position="top-center"
+          toastOptions={toastOptions}
+        />
+      </Box>
+    </>
   );
 };
 

--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -1,11 +1,12 @@
 // src/app/App.jsx
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { Box } from '@mui/material';
 import { Toaster } from 'react-hot-toast';
 import toast from 'react-hot-toast';
 import MealPrep from '../shared/components/layout/MealPrep';
 import { UserProvider } from '../features/auth/UserContext';
 import { ThemeProvider } from '../shared/context/ThemeContext';
+import { useAppTheme } from '../shared/context/ThemeContext';
 import { MacroTargetsProvider } from '../shared/context/MacroTargetsContext';
 import ErrorBoundary from '../shared/components/ui/ErrorBoundary';
 import OfflineBanner from '../shared/components/layout/OfflineBanner';
@@ -14,6 +15,31 @@ import { hasCompletedOnboarding, completeOnboarding } from '../shared/services/o
 
 const AppContent = () => {
   const [showOnboarding, setShowOnboarding] = useState(false);
+  const { muiTheme } = useAppTheme();
+
+  const toastOptions = useMemo(() => {
+    const toastConfig = muiTheme.custom?.toast ?? {};
+    return {
+      duration: 4000,
+      className: toastConfig.className || '',
+      success: {
+        duration: 3000,
+        className: toastConfig.success?.className || toastConfig.className || '',
+        iconTheme: toastConfig.success?.iconTheme ?? {
+          primary: toastConfig.success?.primary ?? muiTheme.palette.success.main,
+          secondary: toastConfig.success?.secondary ?? muiTheme.palette.background.default,
+        },
+      },
+      error: {
+        duration: 5000,
+        className: toastConfig.error?.className || toastConfig.className || '',
+        iconTheme: toastConfig.error?.iconTheme ?? {
+          primary: toastConfig.error?.primary ?? muiTheme.palette.error.main,
+          secondary: toastConfig.error?.secondary ?? muiTheme.palette.background.default,
+        },
+      },
+    };
+  }, [muiTheme]);
 
   // Show onboarding for all users (guest or authenticated) who haven't completed it
   useEffect(() => {
@@ -48,6 +74,10 @@ const AppContent = () => {
           toast.success("Welcome! Let's start planning your meals.");
         }}
       />
+      <Toaster
+        position="top-center"
+        toastOptions={toastOptions}
+      />
     </Box>
   );
 };
@@ -58,29 +88,6 @@ const App = () => (
       <UserProvider>
         <MacroTargetsProvider>
           <AppContent />
-          <Toaster
-          position="top-center"
-          toastOptions={{
-            duration: 4000,
-            className: 'toast-neon',
-            success: {
-              duration: 3000,
-              className: 'toast-neon toast-neon-success',
-              iconTheme: {
-                primary: '#39ff7f',
-                secondary: '#12121e',
-              },
-            },
-            error: {
-              duration: 5000,
-              className: 'toast-neon toast-neon-error',
-              iconTheme: {
-                primary: '#ff4757',
-                secondary: '#12121e',
-              },
-            },
-          }}
-        />
         </MacroTargetsProvider>
       </UserProvider>
     </ThemeProvider>

--- a/src/features/account/AccountPage.jsx
+++ b/src/features/account/AccountPage.jsx
@@ -19,6 +19,7 @@ import Login from '../auth/Login';
 import ConfirmDialog from '../../shared/components/ui/ConfirmDialog';
 import { loadUserPreferences, updateUserPreference } from '../../shared/services/userPreferences';
 import { getGuestDataSummary } from '../../shared/services/guestMigration';
+import ThemeSelector from './ThemeSelector';
 
 const FeatureCard = ({ title, description, status }) => (
   <Card variant="outlined" sx={{ borderRadius: 2 }}>
@@ -243,6 +244,8 @@ const AccountPage = () => {
                     </Typography>
                   </CardContent>
                 </Card>
+
+                <ThemeSelector />
               </Stack>
             </CardContent>
           </Card>
@@ -346,6 +349,8 @@ const AccountPage = () => {
                 </Card>
               </Grid>
             </Grid>
+
+            <ThemeSelector />
 
             {/* Preferences */}
             <Card variant="outlined" sx={{ borderRadius: 3, mt: 2 }}>

--- a/src/features/account/CustomThemeEditor.jsx
+++ b/src/features/account/CustomThemeEditor.jsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import {
+  Box,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  Slider,
+  Stack,
+  ToggleButton,
+  ToggleButtonGroup,
+  Typography,
+} from '@mui/material';
+import { useAppTheme } from '../../shared/context/ThemeContext';
+import { FONT_PAIRS } from '../../shared/context/themes';
+
+const colorPickerSx = {
+  width: 48,
+  height: 48,
+  border: 'none',
+  cursor: 'pointer',
+  borderRadius: '8px',
+  padding: 0,
+};
+
+const CustomThemeEditor = () => {
+  const { customConfig, setCustomConfig } = useAppTheme();
+
+  const update = (key, value) => {
+    setCustomConfig({ ...customConfig, [key]: value });
+  };
+
+  return (
+    <Stack spacing={3} sx={{ mt: 2 }}>
+      {/* Color pickers */}
+      <Stack direction="row" spacing={4}>
+        <Box>
+          <Typography variant="body2" fontWeight={600} sx={{ mb: 0.5 }}>
+            Primary
+          </Typography>
+          <input
+            type="color"
+            value={customConfig.primaryColor}
+            onChange={(e) => update('primaryColor', e.target.value)}
+            style={colorPickerSx}
+          />
+        </Box>
+        <Box>
+          <Typography variant="body2" fontWeight={600} sx={{ mb: 0.5 }}>
+            Accent
+          </Typography>
+          <input
+            type="color"
+            value={customConfig.accentColor}
+            onChange={(e) => update('accentColor', e.target.value)}
+            style={colorPickerSx}
+          />
+        </Box>
+      </Stack>
+
+      {/* Font pair dropdown */}
+      <FormControl fullWidth size="small">
+        <InputLabel id="font-pair-label">Font Pair</InputLabel>
+        <Select
+          labelId="font-pair-label"
+          label="Font Pair"
+          value={customConfig.fontPair}
+          onChange={(e) => update('fontPair', e.target.value)}
+        >
+          {Object.entries(FONT_PAIRS).map(([key, pair]) => (
+            <MenuItem key={key} value={key}>
+              {pair.label}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+
+      {/* Border radius slider */}
+      <Box>
+        <Typography variant="body2" fontWeight={600} sx={{ mb: 1 }}>
+          Border Radius: {customConfig.borderRadius}px
+        </Typography>
+        <Slider
+          value={customConfig.borderRadius}
+          onChange={(_, val) => update('borderRadius', val)}
+          min={0}
+          max={24}
+          step={2}
+          valueLabelDisplay="auto"
+        />
+      </Box>
+
+      {/* Glow style toggle */}
+      <Box>
+        <Typography variant="body2" fontWeight={600} sx={{ mb: 1 }}>
+          Glow Style
+        </Typography>
+        <ToggleButtonGroup
+          value={customConfig.glowStyle}
+          exclusive
+          onChange={(_, val) => {
+            if (val !== null) update('glowStyle', val);
+          }}
+          size="small"
+        >
+          <ToggleButton value="none">None</ToggleButton>
+          <ToggleButton value="soft">Soft</ToggleButton>
+          <ToggleButton value="neon">Neon</ToggleButton>
+        </ToggleButtonGroup>
+      </Box>
+    </Stack>
+  );
+};
+
+export default CustomThemeEditor;

--- a/src/features/account/ThemeSelector.jsx
+++ b/src/features/account/ThemeSelector.jsx
@@ -1,0 +1,141 @@
+import React from 'react';
+import { Box, Card, CardContent, CardHeader, Grid, Typography } from '@mui/material';
+import CheckCircleIcon from '@mui/icons-material/CheckCircleRounded';
+import { useAppTheme } from '../../shared/context/ThemeContext';
+import CustomThemeEditor from './CustomThemeEditor';
+
+const ThemeSwatch = ({ theme, isActive, isDark, onClick, customConfig }) => {
+  // For the custom theme, derive preview colors from customConfig
+  const preview =
+    theme.id === 'custom' && customConfig
+      ? {
+        primary: customConfig.primaryColor,
+        secondary: customConfig.accentColor,
+        bg: '#f9fafb',
+        bgDark: '#111827',
+      }
+      : theme.preview;
+
+  const bgColor = preview
+    ? isDark
+      ? preview.bgDark
+      : preview.bg
+    : isDark
+      ? '#111827'
+      : '#f9fafb';
+
+  return (
+    <Box
+      onClick={onClick}
+      sx={{
+        cursor: 'pointer',
+        borderRadius: 2,
+        border: 2,
+        borderColor: isActive ? 'primary.main' : 'divider',
+        overflow: 'hidden',
+        transition: 'all 200ms ease',
+        position: 'relative',
+        '&:hover': {
+          borderColor: isActive ? 'primary.main' : 'text.secondary',
+        },
+      }}
+    >
+      {/* Color preview bar */}
+      <Box
+        sx={{
+          height: 48,
+          display: 'flex',
+          bgcolor: bgColor,
+        }}
+      >
+        <Box
+          sx={{
+            flex: 1,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <Box
+            sx={{
+              width: '60%',
+              height: 20,
+              borderRadius: 1,
+              bgcolor: preview?.primary || '#888',
+            }}
+          />
+        </Box>
+        <Box
+          sx={{
+            flex: 1,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <Box
+            sx={{
+              width: '60%',
+              height: 20,
+              borderRadius: 1,
+              bgcolor: preview?.secondary || '#aaa',
+            }}
+          />
+        </Box>
+      </Box>
+
+      {/* Theme name label */}
+      <Box sx={{ px: 1, py: 0.75, textAlign: 'center' }}>
+        <Typography variant="caption" fontWeight={600} noWrap>
+          {theme.label}
+        </Typography>
+      </Box>
+
+      {/* Active check icon */}
+      {isActive && (
+        <CheckCircleIcon
+          color="primary"
+          sx={{
+            position: 'absolute',
+            top: 4,
+            right: 4,
+            fontSize: 20,
+            bgcolor: 'background.paper',
+            borderRadius: '50%',
+          }}
+        />
+      )}
+    </Box>
+  );
+};
+
+const ThemeSelector = () => {
+  const { themeName, setThemeName, isDark, themeList, customConfig } = useAppTheme();
+
+  return (
+    <Card variant="outlined" sx={{ borderRadius: 3 }}>
+      <CardHeader
+        title={<Typography variant="h6" fontWeight={800}>Theme</Typography>}
+      />
+      <CardContent>
+        <Grid container spacing={1.5}>
+          {themeList.map((theme) => (
+            <Grid key={theme.id} size={{ xs: 4, sm: 3, md: 2 }}>
+              <ThemeSwatch
+                theme={theme}
+                isActive={themeName === theme.id}
+                isDark={isDark}
+                onClick={() => setThemeName(theme.id)}
+                customConfig={customConfig}
+              />
+            </Grid>
+          ))}
+        </Grid>
+
+        {themeName === 'custom' && <CustomThemeEditor />}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default ThemeSelector;

--- a/src/features/ingredients/ServingSizePreviewModal.jsx
+++ b/src/features/ingredients/ServingSizePreviewModal.jsx
@@ -21,14 +21,6 @@ import {
 } from '@mui/icons-material';
 import { alpha, useTheme } from '@mui/material/styles';
 
-// Tokyo Nights macro color mapping for nutrition chips
-const CHIP_COLORS = {
-  calories: '#ffb020',
-  protein: '#00e5ff',
-  carbs: '#ff2d78',
-  fat: '#a855f7',
-};
-
 export default function ServingSizePreviewModal({
   open,
   onClose,
@@ -40,6 +32,12 @@ export default function ServingSizePreviewModal({
   const theme = useTheme();
   const isDark = theme.palette.mode === 'dark';
   const chipAlpha = isDark ? 0.15 : 0.1;
+  const macroColors = theme.custom?.macroColors ?? {
+    calories: theme.palette.warning.main,
+    protein: theme.palette.info.main,
+    carbs: theme.palette.primary.main,
+    fat: theme.palette.secondary.main,
+  };
   const [selectedDefault, setSelectedDefault] = useState('100g');
 
   const handleConfirm = () => {
@@ -58,22 +56,22 @@ export default function ServingSizePreviewModal({
       <Chip
         size="small"
         label={`${cal} kcal`}
-        sx={{ bgcolor: alpha(CHIP_COLORS.calories, chipAlpha), color: CHIP_COLORS.calories }}
+        sx={{ bgcolor: alpha(macroColors.calories, chipAlpha), color: macroColors.calories }}
       />
       <Chip
         size="small"
         label={`P: ${p}g`}
-        sx={{ bgcolor: alpha(CHIP_COLORS.protein, chipAlpha), color: CHIP_COLORS.protein }}
+        sx={{ bgcolor: alpha(macroColors.protein, chipAlpha), color: macroColors.protein }}
       />
       <Chip
         size="small"
         label={`C: ${c}g`}
-        sx={{ bgcolor: alpha(CHIP_COLORS.carbs, chipAlpha), color: CHIP_COLORS.carbs }}
+        sx={{ bgcolor: alpha(macroColors.carbs, chipAlpha), color: macroColors.carbs }}
       />
       <Chip
         size="small"
         label={`F: ${f}g`}
-        sx={{ bgcolor: alpha(CHIP_COLORS.fat, chipAlpha), color: CHIP_COLORS.fat }}
+        sx={{ bgcolor: alpha(macroColors.fat, chipAlpha), color: macroColors.fat }}
       />
     </Stack>
   );

--- a/src/features/meal-planner/IngredientCard.jsx
+++ b/src/features/meal-planner/IngredientCard.jsx
@@ -13,12 +13,11 @@ import {
 import { alpha, useTheme } from '@mui/material/styles';
 import { calculateNutrition } from '../ingredients/nutritionHelpers';
 
-// Tokyo Nights macro color mapping
-const MACRO_COLORS = {
-  calories: { main: '#ffb020', label: 'Cal' },   // warm amber
-  protein:  { main: '#00e5ff', label: 'P' },      // cyan
-  carbs:    { main: '#ff2d78', label: 'C' },      // hot pink
-  fat:      { main: '#a855f7', label: 'F' },      // purple
+const MACRO_LABELS = {
+  calories: 'Cal',
+  protein: 'P',
+  carbs: 'C',
+  fat: 'F',
 };
 
 const IngredientCard = ({
@@ -30,6 +29,12 @@ const IngredientCard = ({
 }) => {
   const theme = useTheme();
   const isDark = theme.palette.mode === 'dark';
+  const macroColors = theme.custom?.macroColors ?? {
+    calories: theme.palette.warning.main,
+    protein: theme.palette.info.main,
+    carbs: theme.palette.primary.main,
+    fat: theme.palette.secondary.main,
+  };
   const totalGrams = ingredient.grams || ingredient.gramsPerUnit || 100;
   const quantity = ingredient.quantity || 1;
   const nutrition = calculateNutrition(ingredient);
@@ -63,7 +68,7 @@ const IngredientCard = ({
         borderColor: isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.08)',
         transition: 'all 250ms ease-out',
         '&:hover': {
-          borderColor: isDark ? 'rgba(255,45,120,0.15)' : 'rgba(214,36,94,0.1)',
+          borderColor: alpha(theme.palette.primary.main, isDark ? 0.15 : 0.1),
         },
       }}
     >
@@ -96,11 +101,11 @@ const IngredientCard = ({
             onClick={() => onDecrease(ingredient.id)}
             size="medium"
             sx={{
-              bgcolor: isDark ? 'rgba(0,229,255,0.12)' : 'rgba(0,184,212,0.1)',
-              color: isDark ? '#00e5ff' : '#00b8d4',
+              bgcolor: alpha(theme.palette.secondary.main, isDark ? 0.12 : 0.1),
+              color: theme.palette.secondary.main,
               '&:hover': {
-                bgcolor: isDark ? 'rgba(0,229,255,0.2)' : 'rgba(0,184,212,0.18)',
-                boxShadow: isDark ? '0 0 12px rgba(0,229,255,0.2)' : 'none',
+                bgcolor: alpha(theme.palette.secondary.main, isDark ? 0.2 : 0.18),
+                boxShadow: isDark ? `0 0 12px ${alpha(theme.palette.secondary.main, 0.2)}` : 'none',
               },
               width: 44,
               height: 44,
@@ -122,11 +127,11 @@ const IngredientCard = ({
             onClick={() => onIncrease(ingredient.id)}
             size="medium"
             sx={{
-              bgcolor: isDark ? 'rgba(57,255,127,0.12)' : 'rgba(46,204,113,0.1)',
-              color: isDark ? '#39ff7f' : '#2ecc71',
+              bgcolor: alpha(theme.palette.success.main, isDark ? 0.12 : 0.1),
+              color: theme.palette.success.main,
               '&:hover': {
-                bgcolor: isDark ? 'rgba(57,255,127,0.2)' : 'rgba(46,204,113,0.18)',
-                boxShadow: isDark ? '0 0 12px rgba(57,255,127,0.2)' : 'none',
+                bgcolor: alpha(theme.palette.success.main, isDark ? 0.2 : 0.18),
+                boxShadow: isDark ? `0 0 12px ${alpha(theme.palette.success.main, 0.2)}` : 'none',
               },
               width: 44,
               height: 44,
@@ -148,24 +153,24 @@ const IngredientCard = ({
         }}
       >
         <NutritionBox
-          label={MACRO_COLORS.calories.label}
+          label={MACRO_LABELS.calories}
           value={Math.round(nutrition.calories)}
-          color={MACRO_COLORS.calories.main}
+          color={macroColors.calories}
         />
         <NutritionBox
-          label={MACRO_COLORS.protein.label}
+          label={MACRO_LABELS.protein}
           value={`${Math.round(nutrition.protein)}g`}
-          color={MACRO_COLORS.protein.main}
+          color={macroColors.protein}
         />
         <NutritionBox
-          label={MACRO_COLORS.carbs.label}
+          label={MACRO_LABELS.carbs}
           value={`${Math.round(nutrition.carbs)}g`}
-          color={MACRO_COLORS.carbs.main}
+          color={macroColors.carbs}
         />
         <NutritionBox
-          label={MACRO_COLORS.fat.label}
+          label={MACRO_LABELS.fat}
           value={`${Math.round(nutrition.fat)}g`}
-          color={MACRO_COLORS.fat.main}
+          color={macroColors.fat}
         />
       </Box>
     </Paper>

--- a/src/index.css
+++ b/src/index.css
@@ -1,12 +1,12 @@
 /* ============================================================================
-   TOKYO NIGHTS — Base Styles
+   BASE STYLES — Theme-agnostic defaults (overridden by MUI CssBaseline)
    ============================================================================ */
 
 body {
   margin: 0;
-  font-family: "Urbanist", system-ui, sans-serif;
-  background-color: #0a0a12;
-  color: #e8e6f0;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background-color: #f9fafb;
+  color: #111827;
 }
 
 /* ============================================================================
@@ -44,19 +44,19 @@ a,
 }
 
 /* ============================================================================
-   TYPOGRAPHY — Orbitron headings
+   TYPOGRAPHY — Scoped to Tokyo Nights
    ============================================================================ */
 
-h1,
-h2,
-h3 {
+.theme-tokyo-nights h1,
+.theme-tokyo-nights h2,
+.theme-tokyo-nights h3 {
   font-family: "Orbitron", sans-serif;
   letter-spacing: 0.5px;
   text-transform: uppercase;
 }
 
 /* ============================================================================
-   NEON KEYFRAME ANIMATIONS
+   KEYFRAME ANIMATIONS (global — referenced by name)
    ============================================================================ */
 
 @keyframes neonPulse {
@@ -95,32 +95,14 @@ h3 {
   }
 }
 
-/* ============================================================================
-   EXISTING ANIMATIONS (updated)
-   ============================================================================ */
-
 @keyframes wiggle {
   0%, 100% { transform: rotate(0deg); }
   50% { transform: rotate(15deg); }
 }
 
-.wiggle:hover {
-  animation: wiggle 0.5s ease-in-out;
-}
-
 @keyframes confetti {
   0% { opacity: 1; transform: translate(-50%, 0); }
   100% { opacity: 0; transform: translate(-50%, -100%); }
-}
-
-.confetti {
-  position: fixed;
-  top: 20%;
-  left: 50%;
-  transform: translateX(-50%);
-  font-size: 3rem;
-  pointer-events: none;
-  animation: confetti 2s forwards;
 }
 
 @keyframes tabPanelIn {
@@ -131,20 +113,6 @@ h3 {
   to {
     opacity: 1;
     transform: translateY(0);
-  }
-}
-
-.tab-panel {
-  will-change: opacity, transform;
-}
-
-.tab-panel.tab-panel-active {
-  animation: tabPanelIn 160ms ease-out;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .tab-panel.tab-panel-active {
-    animation: none;
   }
 }
 
@@ -177,49 +145,38 @@ h3 {
   }
 }
 
-.tab-stagger.tab-stagger-active > *:not([data-stagger-skip]) {
-  opacity: 0;
-  transform: translateY(12px);
-  animation: tabFadeUp 0.45s ease forwards;
-  animation-delay: calc(var(--stagger-index, 0) * 50ms);
+/* ============================================================================
+   GLOBAL ANIMATIONS & CLASSES
+   ============================================================================ */
+
+.wiggle:hover {
+  animation: wiggle 0.5s ease-in-out;
 }
 
-.tab-stagger.tab-stagger-active > *:not([data-stagger-skip]):nth-child(2) { --stagger-index: 1; }
-.tab-stagger.tab-stagger-active > *:not([data-stagger-skip]):nth-child(3) { --stagger-index: 2; }
-.tab-stagger.tab-stagger-active > *:not([data-stagger-skip]):nth-child(4) { --stagger-index: 3; }
-.tab-stagger.tab-stagger-active > *:not([data-stagger-skip]):nth-child(5) { --stagger-index: 4; }
-.tab-stagger.tab-stagger-active > *:not([data-stagger-skip]):nth-child(6) { --stagger-index: 5; }
-.tab-stagger.tab-stagger-active > *:not([data-stagger-skip]):nth-child(7) { --stagger-index: 6; }
-.tab-stagger.tab-stagger-active > *:not([data-stagger-skip]):nth-child(8) { --stagger-index: 7; }
-.tab-stagger.tab-stagger-active > *:not([data-stagger-skip]):nth-child(9) { --stagger-index: 8; }
-.tab-stagger.tab-stagger-active > *:not([data-stagger-skip]):nth-child(10) { --stagger-index: 9; }
-.tab-stagger.tab-stagger-active > *:not([data-stagger-skip]):nth-child(11) { --stagger-index: 10; }
-.tab-stagger.tab-stagger-active > *:not([data-stagger-skip]):nth-child(12) { --stagger-index: 11; }
-.tab-stagger.tab-stagger-active > *:not([data-stagger-skip]):nth-child(13) { --stagger-index: 12; }
-.tab-stagger.tab-stagger-active > *:not([data-stagger-skip]):nth-child(14) { --stagger-index: 13; }
-.tab-stagger.tab-stagger-active > *:not([data-stagger-skip]):nth-child(15) { --stagger-index: 14; }
-
-@media (prefers-reduced-motion: reduce) {
-  .tab-stagger.tab-stagger-active > *:not([data-stagger-skip]) {
-    animation: none;
-    opacity: 1;
-    transform: none;
-  }
-}
-
-.cheer {
+.confetti {
   position: fixed;
-  top: 1rem;
+  top: 20%;
   left: 50%;
   transform: translateX(-50%);
-  background-color: rgba(255, 176, 32, 0.15);
-  color: #ffb020;
-  padding: 0.5rem 1rem;
-  border-radius: 9999px;
-  border: 1px solid rgba(255, 176, 32, 0.3);
+  font-size: 3rem;
+  pointer-events: none;
   animation: confetti 2s forwards;
 }
 
+.tab-panel {
+  will-change: opacity, transform;
+}
+
+.tab-panel.tab-panel-active {
+  animation: tabPanelIn 160ms ease-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tab-panel.tab-panel-active {
+    animation: none;
+  }
+}
+
 .tab-stagger.tab-stagger-active > *:not([data-stagger-skip]) {
   opacity: 0;
   transform: translateY(12px);
@@ -250,6 +207,7 @@ h3 {
   }
 }
 
+/* Generic cheer badge (light/neutral) */
 .cheer {
   position: fixed;
   top: 1rem;
@@ -262,8 +220,18 @@ h3 {
   animation: confetti 2s forwards;
 }
 
-/* Toast styling */
-.toast-neon {
+/* Tokyo Nights cheer variant (dark amber glow) */
+.theme-tokyo-nights .cheer {
+  background-color: rgba(255, 176, 32, 0.15);
+  color: #ffb020;
+  border: 1px solid rgba(255, 176, 32, 0.3);
+}
+
+/* ============================================================================
+   TOAST STYLING — Scoped to Tokyo Nights
+   ============================================================================ */
+
+.theme-tokyo-nights .toast-neon {
   font-family: "Urbanist", "Inter", system-ui, sans-serif;
   font-size: 0.9rem;
   background: rgba(18, 18, 30, 0.85);
@@ -279,7 +247,7 @@ h3 {
   -webkit-backdrop-filter: blur(14px) saturate(140%);
 }
 
-.toast-neon-success {
+.theme-tokyo-nights .toast-neon-success {
   border-color: rgba(57, 255, 127, 0.25);
   border-left-color: rgba(57, 255, 127, 0.85);
   box-shadow:
@@ -287,7 +255,7 @@ h3 {
     0 0 18px rgba(57, 255, 127, 0.12);
 }
 
-.toast-neon-error {
+.theme-tokyo-nights .toast-neon-error {
   border-color: rgba(255, 71, 87, 0.35);
   border-left-color: rgba(255, 71, 87, 0.9);
   box-shadow:
@@ -295,25 +263,28 @@ h3 {
     0 0 18px rgba(255, 71, 87, 0.12);
 }
 
-.toast-neon svg {
+.theme-tokyo-nights .toast-neon svg {
   filter: drop-shadow(0 0 6px rgba(255, 45, 120, 0.45));
 }
 
-/* Skeleton shimmer */
-.MuiSkeleton-root {
+/* ============================================================================
+   SKELETON SHIMMER — Scoped to Tokyo Nights
+   ============================================================================ */
+
+.theme-tokyo-nights .MuiSkeleton-root {
   background-image: linear-gradient(90deg, #12121e 0%, #1a1a2e 50%, #12121e 100%);
   background-size: 200% 100%;
   animation: skeletonShimmer 1.6s ease-in-out infinite;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .MuiSkeleton-root {
+  .theme-tokyo-nights .MuiSkeleton-root {
     animation: none;
   }
 }
 
 /* ============================================================================
-   SCROLLBAR — Dark glass with neon thumb
+   SCROLLBAR — Neutral global defaults + Tokyo Nights neon overrides
    ============================================================================ */
 
 .overflow-x-auto {
@@ -321,47 +292,62 @@ h3 {
   -webkit-overflow-scrolling: touch;
 }
 
-.overflow-x-auto::-webkit-scrollbar {
-  height: 6px;
-}
-
-.overflow-x-auto::-webkit-scrollbar-track {
-  background: rgba(255, 255, 255, 0.04);
-  border-radius: 3px;
-}
-
-.overflow-x-auto::-webkit-scrollbar-thumb {
-  background: rgba(255, 45, 120, 0.4);
-  border-radius: 3px;
-}
-
-.overflow-x-auto::-webkit-scrollbar-thumb:hover {
-  background: rgba(255, 45, 120, 0.6);
-}
-
-/* Global scrollbar */
+/* Global scrollbar (neutral) */
 ::-webkit-scrollbar {
   width: 6px;
 }
 
 ::-webkit-scrollbar-track {
-  background: rgba(255, 255, 255, 0.02);
+  background: rgba(0, 0, 0, 0.02);
 }
 
 ::-webkit-scrollbar-thumb {
-  background: rgba(255, 45, 120, 0.3);
+  background: rgba(0, 0, 0, 0.15);
   border-radius: 3px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
+  background: rgba(0, 0, 0, 0.25);
+}
+
+/* Tokyo Nights scrollbar (neon pink) */
+.theme-tokyo-nights ::-webkit-scrollbar-track {
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.theme-tokyo-nights ::-webkit-scrollbar-thumb {
+  background: rgba(255, 45, 120, 0.3);
+  border-radius: 3px;
+}
+
+.theme-tokyo-nights ::-webkit-scrollbar-thumb:hover {
   background: rgba(255, 45, 120, 0.5);
 }
 
+/* Tokyo Nights horizontal scrollbar */
+.theme-tokyo-nights .overflow-x-auto::-webkit-scrollbar {
+  height: 6px;
+}
+
+.theme-tokyo-nights .overflow-x-auto::-webkit-scrollbar-track {
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 3px;
+}
+
+.theme-tokyo-nights .overflow-x-auto::-webkit-scrollbar-thumb {
+  background: rgba(255, 45, 120, 0.4);
+  border-radius: 3px;
+}
+
+.theme-tokyo-nights .overflow-x-auto::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 45, 120, 0.6);
+}
+
 /* ============================================================================
-   CUSTOM SLIDER — Neon glow thumb
+   CUSTOM SLIDER — Scoped to Tokyo Nights
    ============================================================================ */
 
-input[type="range"]::-webkit-slider-thumb {
+.theme-tokyo-nights input[type="range"]::-webkit-slider-thumb {
   appearance: none;
   height: 20px;
   width: 20px;
@@ -371,7 +357,7 @@ input[type="range"]::-webkit-slider-thumb {
   box-shadow: 0 0 10px rgba(255, 45, 120, 0.5);
 }
 
-input[type="range"]::-moz-range-thumb {
+.theme-tokyo-nights input[type="range"]::-moz-range-thumb {
   height: 20px;
   width: 20px;
   border-radius: 50%;

--- a/src/shared/components/layout/MealPrep.jsx
+++ b/src/shared/components/layout/MealPrep.jsx
@@ -26,7 +26,7 @@ import {
   useMediaQuery,
   useScrollTrigger,
 } from "@mui/material";
-import { useTheme } from "@mui/material/styles";
+import { alpha, useTheme } from "@mui/material/styles";
 // Eager load: Default tab (critical for first paint)
 import MealPrepCalculator from "../../../features/meal-planner/MealPrepCalculator";
 // Lazy load: Non-default tabs (loaded on demand)
@@ -254,13 +254,9 @@ const MealPrep = () => {
         pb: isDesktop ? 4 : 8,
         background: isDesktop
           ? `radial-gradient(circle at 20% 20%, ${
-              isDark
-                ? "rgba(255,45,120,0.06)"
-                : "rgba(214,36,94,0.04)"
+              alpha(theme.palette.primary.main, isDark ? 0.06 : 0.04)
             }, transparent 40%), radial-gradient(circle at 80% 0%, ${
-              isDark
-                ? "rgba(0,229,255,0.06)"
-                : "rgba(0,184,212,0.04)"
+              alpha(theme.palette.secondary.main, isDark ? 0.06 : 0.04)
             }, transparent 35%), ${theme.palette.background.default}`
           : theme.palette.background.default,
         transition: theme.transitions.create("background-color"),
@@ -280,15 +276,13 @@ const MealPrep = () => {
       >
         <Toolbar disableGutters sx={{ gap: { xs: 1, md: 2 }, alignItems: "center" }}>
           <Stack direction="row" spacing={1} alignItems="center" sx={{ minWidth: 0 }}>
-            {/* PTM Logo with neon glow */}
+            {/* PTM Logo */}
             <Box
               sx={{
                 width: { xs: 36, md: 44 },
                 height: { xs: 36, md: 44 },
                 borderRadius: 2,
-                background: isDark
-                  ? "linear-gradient(135deg, #ff2d78 0%, #a855f7 100%)"
-                  : "linear-gradient(135deg, #d6245e 0%, #8b3fd4 100%)",
+                background: `linear-gradient(135deg, ${theme.palette.primary.main} 0%, ${theme.palette.secondary.main} 100%)`,
                 color: "#fff",
                 display: "grid",
                 placeItems: "center",
@@ -297,8 +291,8 @@ const MealPrep = () => {
                 fontSize: "0.75rem",
                 letterSpacing: 1,
                 boxShadow: isDark
-                  ? "0 0 20px rgba(255,45,120,0.4), 0 0 60px rgba(255,45,120,0.15)"
-                  : "0 4px 16px rgba(214,36,94,0.3)",
+                  ? `0 0 20px ${alpha(theme.palette.primary.main, 0.4)}, 0 0 60px ${alpha(theme.palette.primary.main, 0.15)}`
+                  : `0 4px 16px ${alpha(theme.palette.primary.main, 0.3)}`,
                 animation: isDark ? "neonPulse 3s ease-in-out infinite" : "none",
               }}
             >
@@ -320,7 +314,7 @@ const MealPrep = () => {
                       height: 22,
                       fontWeight: 700,
                       fontSize: "0.65rem",
-                      borderColor: isDark ? "rgba(255,45,120,0.4)" : "primary.main",
+                      borderColor: isDark ? alpha(theme.palette.primary.main, 0.4) : "primary.main",
                       color: "primary.main",
                       border: "1px solid",
                     }}
@@ -372,7 +366,7 @@ const MealPrep = () => {
           )}
 
           <Stack direction="row" alignItems="center" spacing={1.25} sx={{ ml: "auto" }}>
-            {/* Status indicator with neon pulse - hide on mobile */}
+            {/* Status indicator - hide on mobile */}
             {isDesktop && (
               <Stack
                 direction="row"
@@ -384,14 +378,14 @@ const MealPrep = () => {
                   borderRadius: 9999,
                   border: "1px solid",
                   borderColor: isOffline
-                    ? isDark ? "rgba(255,176,32,0.4)" : "warning.main"
-                    : isDark ? "rgba(57,255,127,0.4)" : "success.main",
+                    ? isDark ? alpha(theme.palette.warning.main, 0.4) : "warning.main"
+                    : isDark ? alpha(theme.palette.success.main, 0.4) : "success.main",
                   backgroundColor: isOffline
-                    ? isDark ? "rgba(255,176,32,0.08)" : "warning.light"
-                    : isDark ? "rgba(57,255,127,0.08)" : "success.light",
+                    ? isDark ? alpha(theme.palette.warning.main, 0.08) : "warning.light"
+                    : isDark ? alpha(theme.palette.success.main, 0.08) : "success.light",
                   color: isOffline
-                    ? isDark ? "#ffb020" : "warning.dark"
-                    : isDark ? "#39ff7f" : "success.dark",
+                    ? isDark ? theme.palette.warning.main : "warning.dark"
+                    : isDark ? theme.palette.success.main : "success.dark",
                 }}
               >
                 <Box
@@ -426,8 +420,8 @@ const MealPrep = () => {
                       height: 38,
                       bgcolor: "primary.main",
                       fontWeight: 700,
-                      border: isDark ? "2px solid rgba(255,45,120,0.4)" : "2px solid",
-                      borderColor: isDark ? undefined : "primary.light",
+                      border: "2px solid",
+                      borderColor: isDark ? alpha(theme.palette.primary.main, 0.4) : "primary.light",
                     }}
                   >
                     {(user?.displayName || "User").charAt(0).toUpperCase()}
@@ -490,7 +484,7 @@ const MealPrep = () => {
               left: 0,
               right: 0,
               height: "1px",
-              background: "linear-gradient(90deg, transparent, rgba(255,45,120,0.3), rgba(0,229,255,0.3), transparent)",
+              background: `linear-gradient(90deg, transparent, ${alpha(theme.palette.primary.main, 0.3)}, ${alpha(theme.palette.secondary.main, 0.3)}, transparent)`,
             } : {},
           }}
         >

--- a/src/shared/components/layout/ThemeToggle.jsx
+++ b/src/shared/components/layout/ThemeToggle.jsx
@@ -15,16 +15,16 @@ const ThemeToggle = () => {
         aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
         sx={(theme) => ({
           border: `1px solid ${isDark ? 'rgba(255,255,255,0.08)' : theme.palette.divider}`,
-          backgroundColor: isDark ? 'rgba(255,176,32,0.08)' : 'rgba(0,0,0,0.04)',
-          color: isDark ? '#ffb020' : theme.palette.text.primary,
+          backgroundColor: isDark ? `${theme.palette.warning.main}14` : 'rgba(0,0,0,0.04)',
+          color: isDark ? theme.palette.warning.main : theme.palette.text.primary,
           transition: theme.transitions.create(['transform', 'box-shadow', 'color'], {
             duration: 250,
           }),
           '&:hover': {
             transform: 'translateY(-1px)',
-            backgroundColor: isDark ? 'rgba(255,176,32,0.15)' : 'rgba(0,0,0,0.08)',
+            backgroundColor: isDark ? `${theme.palette.warning.main}26` : 'rgba(0,0,0,0.08)',
             boxShadow: isDark
-              ? '0 0 16px rgba(255,176,32,0.3)'
+              ? `0 0 16px ${theme.palette.warning.main}4D`
               : theme.shadows[4],
           },
         })}

--- a/src/shared/components/ui/EmptyState.jsx
+++ b/src/shared/components/ui/EmptyState.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { Box, Typography } from '@mui/material';
-import { useTheme } from '@mui/material/styles';
+import { alpha, useTheme } from '@mui/material/styles';
 import SearchOffIcon from '@mui/icons-material/SearchOff';
 
-const NeonPlateIcon = ({ size = 48, color = '#ff2d78' }) => (
+const NeonPlateIcon = ({ size = 48, color }) => (
   <svg width={size} height={size} viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
     <ellipse cx="24" cy="28" rx="18" ry="8" stroke={color} strokeWidth="1.5" opacity="0.6" />
     <ellipse cx="24" cy="26" rx="14" ry="6" stroke={color} strokeWidth="1.5" opacity="0.4" />
@@ -45,7 +45,7 @@ const EmptyState = ({
         borderRadius: 2,
         border: '1px dashed',
         borderColor: isDark
-          ? 'rgba(255,45,120,0.15)'
+          ? alpha(theme.palette.primary.main, 0.15)
           : 'divider',
         ...sx
       }}
@@ -54,7 +54,7 @@ const EmptyState = ({
         {illustration ? (
           <Box
             sx={{
-              bgcolor: isDark ? 'rgba(255,45,120,0.08)' : 'rgba(214,36,94,0.05)',
+              bgcolor: alpha(theme.palette.primary.main, isDark ? 0.08 : 0.05),
               p: 2,
               borderRadius: '50%',
               '& svg': {
@@ -66,18 +66,14 @@ const EmptyState = ({
             {illustration}
           </Box>
         ) : icon === SearchOffIcon ? (
-          <NeonPlateIcon size={48} color={isDark ? '#ff2d78' : '#d6245e'} />
+          <NeonPlateIcon size={48} color={theme.palette.primary.main} />
         ) : (
           <Box
             sx={{
-              bgcolor: isDark
-                ? 'rgba(255,45,120,0.08)'
-                : 'rgba(214,36,94,0.05)',
+              bgcolor: alpha(theme.palette.primary.main, isDark ? 0.08 : 0.05),
               p: 2,
               borderRadius: '50%',
-              color: isDark
-                ? '#ff2d78'
-                : '#d6245e',
+              color: theme.palette.primary.main,
             }}
           >
             <Icon sx={{ fontSize: 40, opacity: 0.7 }} />

--- a/src/shared/components/ui/LoadingSpinner.jsx
+++ b/src/shared/components/ui/LoadingSpinner.jsx
@@ -1,51 +1,37 @@
 import React from 'react';
+import { Box, CircularProgress, Typography } from '@mui/material';
 
 const LoadingSpinner = ({ message = 'Loading...', size = 'medium' }) => {
-  const sizeClasses = {
-    small: { spinner: '16px', fontSize: '0.875rem' },
-    medium: { spinner: '32px', fontSize: '1rem' },
-    large: { spinner: '48px', fontSize: '1.25rem' }
+  const sizeMap = {
+    small: 16,
+    medium: 32,
+    large: 48,
   };
 
-  const { spinner: spinnerSize, fontSize } = sizeClasses[size] || sizeClasses.medium;
-
   return (
-    <div style={{
-      display: 'flex',
-      flexDirection: 'column',
-      alignItems: 'center',
-      justifyContent: 'center',
-      gap: '1rem',
-      padding: '2rem'
-    }}>
-      <div
-        style={{
-          width: spinnerSize,
-          height: spinnerSize,
-          border: '3px solid rgba(255,255,255,0.06)',
-          borderTop: '3px solid #ff2d78',
-          borderRadius: '50%',
-          animation: 'spin 1s linear infinite',
-          boxShadow: '0 0 16px rgba(255,45,120,0.3)',
-        }}
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 2,
+        p: 4,
+      }}
+    >
+      <CircularProgress
+        size={sizeMap[size] || sizeMap.medium}
+        color="primary"
       />
       {message && (
-        <p style={{
-          fontSize,
-          color: '#7a78a0',
-          margin: 0,
-          fontFamily: '"Urbanist", sans-serif',
-        }}>
+        <Typography
+          variant={size === 'small' ? 'caption' : 'body2'}
+          color="text.secondary"
+        >
           {message}
-        </p>
+        </Typography>
       )}
-      <style>{`
-        @keyframes spin {
-          0% { transform: rotate(0deg); }
-          100% { transform: rotate(360deg); }
-        }
-      `}</style>
-    </div>
+    </Box>
   );
 };
 

--- a/src/shared/components/ui/MacroProgressBar.jsx
+++ b/src/shared/components/ui/MacroProgressBar.jsx
@@ -2,14 +2,6 @@ import React from 'react';
 import { Box, LinearProgress, Typography, Tooltip } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 
-// Tokyo Nights macro colors
-const MACRO_THEME_COLORS = {
-  calories: '#ffb020',
-  protein: '#00e5ff',
-  carbs: '#ff2d78',
-  fat: '#a855f7',
-};
-
 const MacroProgressBar = ({
   label,
   actual,

--- a/src/shared/components/ui/PerformanceOverlay.jsx
+++ b/src/shared/components/ui/PerformanceOverlay.jsx
@@ -1,6 +1,7 @@
 // Performance overlay for development mode
 import React, { useState, useEffect } from 'react';
 import { Box, Paper, Typography, IconButton, Collapse } from '@mui/material';
+import { alpha, useTheme } from '@mui/material/styles';
 import CloseIcon from '@mui/icons-material/Close';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import { getTabSwitchStats } from '../../utils/performance';
@@ -16,6 +17,7 @@ import { getTabSwitchStats } from '../../utils/performance';
  * Only shown when performance tracking is enabled (?perf or localStorage ptm_perf=1)
  */
 export const PerformanceOverlay = ({ samples = [] }) => {
+  const theme = useTheme();
   const [visible, setVisible] = useState(true);
   const [expanded, setExpanded] = useState(true);
   const [stats, setStats] = useState({ p50: 0, p75: 0, p95: 0, avg: 0, count: 0 });
@@ -50,7 +52,7 @@ export const PerformanceOverlay = ({ samples = [] }) => {
         width: 280,
         bgcolor: 'rgba(10, 10, 18, 0.95)',
         color: '#e8e6f0',
-        border: '1px solid rgba(255, 45, 120, 0.3)',
+        border: `1px solid ${alpha(theme.palette.primary.main, 0.3)}`,
         borderRadius: 2,
         zIndex: 9999,
         backdropFilter: 'blur(10px)',
@@ -62,10 +64,10 @@ export const PerformanceOverlay = ({ samples = [] }) => {
           alignItems: 'center',
           justifyContent: 'space-between',
           p: 1.5,
-          borderBottom: expanded ? '1px solid rgba(255, 45, 120, 0.2)' : 'none',
+          borderBottom: expanded ? `1px solid ${alpha(theme.palette.primary.main, 0.2)}` : 'none',
         }}
       >
-        <Typography variant="caption" fontWeight={700} sx={{ color: '#ff2d78' }}>
+        <Typography variant="caption" fontWeight={700} sx={{ color: theme.palette.primary.main }}>
           ⚡ PERFORMANCE
         </Typography>
         <Box>
@@ -95,7 +97,7 @@ export const PerformanceOverlay = ({ samples = [] }) => {
         <Box sx={{ p: 1.5 }}>
           {/* Summary Stats */}
           {stats.count > 0 && (
-            <Box sx={{ mb: 1.5, pb: 1.5, borderBottom: '1px solid rgba(255, 45, 120, 0.2)' }}>
+            <Box sx={{ mb: 1.5, pb: 1.5, borderBottom: `1px solid ${alpha(theme.palette.primary.main, 0.2)}` }}>
               <Typography variant="caption" display="block" sx={{ color: '#a8a6b0', mb: 0.5 }}>
                 Tab Switch Stats ({stats.count} samples)
               </Typography>
@@ -152,7 +154,7 @@ export const PerformanceOverlay = ({ samples = [] }) => {
           )}
 
           {/* Thresholds Guide */}
-          <Box sx={{ mt: 1.5, pt: 1.5, borderTop: '1px solid rgba(255, 45, 120, 0.2)' }}>
+          <Box sx={{ mt: 1.5, pt: 1.5, borderTop: `1px solid ${alpha(theme.palette.primary.main, 0.2)}` }}>
             <Typography variant="caption" display="block" sx={{ color: '#a8a6b0', mb: 0.5 }}>
               Thresholds
             </Typography>

--- a/src/shared/context/ThemeContext.jsx
+++ b/src/shared/context/ThemeContext.jsx
@@ -1,16 +1,7 @@
 /* eslint-disable react-refresh/only-export-components */
-import React, {
-  createContext,
-  useContext,
-  useEffect,
-  useMemo,
-  useState,
-} from 'react';
-import {
-  CssBaseline,
-  ThemeProvider as MuiThemeProvider,
-  createTheme,
-} from '@mui/material';
+import React, { createContext, useContext, useEffect, useMemo, useState } from 'react';
+import { CssBaseline, ThemeProvider as MuiThemeProvider, createTheme } from '@mui/material';
+import { getThemeFactory, getThemeList, DEFAULT_THEME, DEFAULT_CUSTOM_CONFIG } from './themes';
 
 const ThemeContext = createContext();
 
@@ -22,396 +13,112 @@ export const useAppTheme = () => {
   return context;
 };
 
-// Tokyo Nights neon glow helpers
-const neonGlow = {
-  pink: '0 0 20px rgba(255,45,120,0.3), 0 0 60px rgba(255,45,120,0.1)',
-  cyan: '0 0 20px rgba(0,229,255,0.3), 0 0 60px rgba(0,229,255,0.1)',
-  amber: '0 0 20px rgba(255,176,32,0.3)',
-  green: '0 0 20px rgba(57,255,127,0.3)',
-  purple: '0 0 20px rgba(168,85,247,0.3)',
+const STORAGE_KEY = 'themePrefs';
+const OLD_STORAGE_KEY = 'theme';
+
+const loadThemePrefs = () => {
+  if (typeof localStorage === 'undefined') return null;
+
+  // Try new format first
+  const saved = localStorage.getItem(STORAGE_KEY);
+  if (saved) {
+    try {
+      return JSON.parse(saved);
+    } catch {
+      return null;
+    }
+  }
+
+  // Migration: old format was 'dark' or 'light' string
+  const oldSaved = localStorage.getItem(OLD_STORAGE_KEY);
+  if (oldSaved) {
+    const migrated = {
+      themeName: 'tokyoNights', // existing users keep Tokyo Nights
+      isDark: oldSaved === 'dark',
+      customConfig: DEFAULT_CUSTOM_CONFIG,
+    };
+    // Write new format and clean up old
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(migrated));
+    localStorage.removeItem(OLD_STORAGE_KEY);
+    return migrated;
+  }
+
+  return null;
 };
 
-export const ThemeProvider = ({ children }) => {
+export const ThemeProvider = ({ children, initialTheme, initialThemeName }) => {
   const prefersDarkMode =
     typeof window !== 'undefined' &&
     window.matchMedia('(prefers-color-scheme: dark)').matches;
 
+  const [themeName, setThemeName] = useState(() => {
+    if (initialThemeName) return initialThemeName;
+    const saved = loadThemePrefs();
+    return saved?.themeName ?? DEFAULT_THEME;
+  });
+
   const [isDark, setIsDark] = useState(() => {
-    const saved =
-      typeof localStorage !== 'undefined'
-        ? localStorage.getItem('theme')
-        : null;
-    if (saved) {
-      return saved === 'dark';
-    }
+    if (initialTheme === 'dark') return true;
+    if (initialTheme === 'light') return false;
+    const saved = loadThemePrefs();
+    if (saved?.isDark !== undefined) return saved.isDark;
     return prefersDarkMode;
   });
 
+  const [customConfig, setCustomConfig] = useState(() => {
+    const saved = loadThemePrefs();
+    return saved?.customConfig ?? DEFAULT_CUSTOM_CONFIG;
+  });
+
+  // Persist to localStorage
+  useEffect(() => {
+    if (typeof localStorage !== 'undefined') {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({ themeName, isDark, customConfig }));
+    }
+  }, [themeName, isDark, customConfig]);
+
+  // Set CSS class on <html> for theme-scoped CSS
   useEffect(() => {
     if (typeof document !== 'undefined') {
+      const themeFactory = getThemeFactory(themeName, customConfig);
+      const themeConfig = themeFactory(isDark);
+      const cssClass = themeConfig.custom?.cssClass || '';
+
+      // Remove all theme classes, add the active one
+      document.documentElement.className =
+        document.documentElement.className
+          .split(' ')
+          .filter(c => !c.startsWith('theme-'))
+          .concat(cssClass)
+          .join(' ')
+          .trim();
+
+      // Also toggle dark class
       document.documentElement.classList.toggle('dark', isDark);
     }
-    if (typeof localStorage !== 'undefined') {
-      localStorage.setItem('theme', isDark ? 'dark' : 'light');
-    }
-  }, [isDark]);
+  }, [themeName, isDark, customConfig]);
 
-  const toggleTheme = () => {
-    setIsDark((prev) => !prev);
-  };
+  const toggleTheme = () => setIsDark(prev => !prev);
 
-  const muiTheme = useMemo(
-    () =>
-      createTheme({
-        palette: {
-          mode: isDark ? 'dark' : 'light',
-          primary: {
-            main: isDark ? '#ff2d78' : '#d6245e',
-            light: isDark ? '#ff6da0' : '#e8507a',
-            dark: isDark ? '#c4205d' : '#a81c4a',
-            contrastText: '#ffffff',
-          },
-          secondary: {
-            main: isDark ? '#00e5ff' : '#00b8d4',
-            light: isDark ? '#6effff' : '#62efff',
-            dark: isDark ? '#00b2c8' : '#008ba3',
-            contrastText: isDark ? '#0a0a12' : '#ffffff',
-          },
-          success: {
-            main: isDark ? '#39ff7f' : '#2ecc71',
-            light: isDark ? '#80ffb0' : '#a3e4bc',
-            dark: isDark ? '#1fb85c' : '#1fa04e',
-          },
-          warning: {
-            main: isDark ? '#ffb020' : '#e09b18',
-            light: isDark ? '#ffd070' : '#f5d890',
-            dark: isDark ? '#c88a18' : '#b07812',
-          },
-          error: {
-            main: isDark ? '#ff4757' : '#e03e4e',
-            light: isDark ? '#ff8a94' : '#f0888f',
-            dark: isDark ? '#cc3644' : '#b0303e',
-          },
-          info: {
-            main: isDark ? '#a855f7' : '#8b3fd4',
-            light: isDark ? '#c88aff' : '#b48ae0',
-            dark: isDark ? '#7c3aed' : '#6d2eb0',
-          },
-          background: {
-            default: isDark ? '#0a0a12' : '#f4f2ee',
-            paper: isDark ? '#12121e' : '#ffffff',
-            accent: isDark ? '#1a1a2e' : '#eae7e0',
-          },
-          text: {
-            primary: isDark ? '#e8e6f0' : '#1a1a2e',
-            secondary: isDark ? '#7a78a0' : '#6b6980',
-          },
-          divider: isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.08)',
-        },
-        shape: {
-          borderRadius: 12,
-        },
-        typography: {
-          fontFamily: '"Urbanist", system-ui, -apple-system, sans-serif',
-          h1: {
-            fontFamily: '"Orbitron", sans-serif',
-            fontWeight: 900,
-            letterSpacing: 1,
-            textTransform: 'uppercase',
-          },
-          h2: {
-            fontFamily: '"Orbitron", sans-serif',
-            fontWeight: 700,
-            letterSpacing: 0.5,
-            textTransform: 'uppercase',
-          },
-          h3: {
-            fontFamily: '"Orbitron", sans-serif',
-            fontWeight: 700,
-            letterSpacing: 0.5,
-            textTransform: 'uppercase',
-          },
-          h4: {
-            fontFamily: '"Orbitron", sans-serif',
-            fontWeight: 700,
-            letterSpacing: 0.25,
-          },
-          h5: {
-            fontFamily: '"Urbanist", sans-serif',
-            fontWeight: 700,
-          },
-          h6: {
-            fontFamily: '"Urbanist", sans-serif',
-            fontWeight: 700,
-          },
-          subtitle1: { fontWeight: 600 },
-          subtitle2: { fontWeight: 600 },
-          button: {
-            textTransform: 'none',
-            fontWeight: 600,
-            letterSpacing: 0.25,
-          },
-          body2: {
-            color: isDark ? '#9a98b8' : '#6b6980',
-          },
-        },
-        components: {
-          MuiButton: {
-            styleOverrides: {
-              root: {
-                borderRadius: 8,
-                transition: 'all 250ms ease-out',
-              },
-              contained: {
-                boxShadow: isDark ? neonGlow.pink : 'none',
-                '&:hover': {
-                  boxShadow: isDark
-                    ? '0 0 30px rgba(255,45,120,0.4), 0 0 80px rgba(255,45,120,0.15)'
-                    : '0 4px 16px rgba(214,36,94,0.3)',
-                },
-              },
-              outlined: {
-                borderColor: isDark ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.12)',
-                '&:hover': {
-                  borderColor: isDark ? '#ff2d78' : '#d6245e',
-                  boxShadow: isDark ? '0 0 12px rgba(255,45,120,0.2)' : 'none',
-                },
-              },
-            },
-          },
-          MuiBackdrop: {
-            styleOverrides: {
-              root: {
-                backgroundColor: isDark
-                  ? 'rgba(2, 6, 23, 0.6)'
-                  : 'rgba(15, 23, 42, 0.35)',
-                backdropFilter: 'blur(6px)',
-                WebkitBackdropFilter: 'blur(6px)',
-              },
-            },
-          },
-          MuiSkeleton: {
-            styleOverrides: {
-              root: {
-                backgroundImage:
-                  'linear-gradient(90deg, #12121e 0%, #1a1a2e 50%, #12121e 100%)',
-                backgroundSize: '200% 100%',
-                animation: 'skeletonShimmer 1.6s ease-in-out infinite',
-              },
-            },
-          },
-          MuiPaper: {
-            styleOverrides: {
-              root: {
-                borderRadius: 16,
-                backgroundImage: 'none',
-                transition: 'box-shadow 250ms ease-out, border-color 250ms ease-out',
-                ...(isDark && {
-                  backgroundColor: '#12121e',
-                  border: '1px solid rgba(255,255,255,0.04)',
-                  '&:hover': {
-                    borderColor: 'rgba(255,45,120,0.15)',
-                  },
-                }),
-              },
-            },
-          },
-          MuiCard: {
-            defaultProps: {
-              elevation: 0,
-            },
-            styleOverrides: {
-              root: {
-                border: `1px solid ${isDark ? 'rgba(255,255,255,0.06)' : '#e2e0d8'}`,
-                boxShadow: isDark
-                  ? '0 4px 30px rgba(0,0,0,0.4)'
-                  : '0 4px 20px rgba(0,0,0,0.06)',
-                transition: 'all 250ms ease-out',
-                '&:hover': {
-                  borderColor: isDark ? 'rgba(255,45,120,0.2)' : 'rgba(214,36,94,0.15)',
-                  boxShadow: isDark
-                    ? '0 4px 30px rgba(0,0,0,0.4), 0 0 20px rgba(255,45,120,0.1)'
-                    : '0 8px 30px rgba(0,0,0,0.08)',
-                },
-              },
-            },
-          },
-          MuiCardContent: {
-            styleOverrides: {
-              root: ({ theme: t }) => ({
-                padding: '16px 16px 12px',
-                [t.breakpoints.up('sm')]: {
-                  padding: '20px 20px 16px',
-                },
-                '&:last-child': {
-                  paddingBottom: 16,
-                  [t.breakpoints.up('sm')]: {
-                    paddingBottom: 20,
-                  },
-                },
-              }),
-            },
-          },
-          MuiAppBar: {
-            styleOverrides: {
-              root: {
-                backgroundColor: isDark
-                  ? 'rgba(10, 10, 18, 0.92)'
-                  : 'rgba(244, 242, 238, 0.95)',
-                backdropFilter: 'blur(14px)',
-                boxShadow: 'none',
-                borderBottom: isDark
-                  ? '1px solid rgba(255,255,255,0.04)'
-                  : '1px solid rgba(0,0,0,0.06)',
-                '&::after': isDark ? {
-                  content: '""',
-                  position: 'absolute',
-                  bottom: 0,
-                  left: 0,
-                  right: 0,
-                  height: '1px',
-                  background: 'linear-gradient(90deg, transparent, rgba(255,45,120,0.4), rgba(0,229,255,0.4), transparent)',
-                } : {},
-              },
-            },
-          },
-          MuiChip: {
-            styleOverrides: {
-              outlined: {
-                borderColor: isDark ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.12)',
-              },
-            },
-          },
-          MuiTab: {
-            styleOverrides: {
-              root: {
-                transition: 'all 250ms ease-out',
-                '&.Mui-selected': {
-                  color: isDark ? '#ff2d78' : '#d6245e',
-                },
-              },
-            },
-          },
-          MuiTabs: {
-            styleOverrides: {
-              indicator: {
-                backgroundColor: isDark ? '#ff2d78' : '#d6245e',
-                height: 3,
-                borderRadius: '3px 3px 0 0',
-                boxShadow: isDark ? '0 0 10px rgba(255,45,120,0.5)' : 'none',
-              },
-            },
-          },
-          MuiTextField: {
-            styleOverrides: {
-              root: {
-                '& .MuiOutlinedInput-root': {
-                  '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
-                    borderColor: isDark ? '#00e5ff' : '#00b8d4',
-                    boxShadow: isDark ? '0 0 12px rgba(0,229,255,0.2)' : 'none',
-                  },
-                },
-              },
-            },
-          },
-          MuiAccordion: {
-            styleOverrides: {
-              root: {
-                backgroundColor: isDark ? '#12121e' : '#ffffff',
-                '&::before': {
-                  display: 'none',
-                },
-              },
-            },
-          },
-          MuiDialog: {
-            styleOverrides: {
-              paper: {
-                backgroundColor: isDark ? 'rgba(18, 18, 30, 0.8)' : '#ffffff',
-                backdropFilter: isDark ? 'blur(20px) saturate(140%)' : 'none',
-                WebkitBackdropFilter: isDark ? 'blur(20px) saturate(140%)' : 'none',
-                border: isDark ? '1px solid rgba(255,255,255,0.06)' : 'none',
-                boxShadow: isDark
-                  ? '0 24px 80px rgba(0,0,0,0.6), 0 0 40px rgba(255,45,120,0.08)'
-                  : '0 24px 80px rgba(0,0,0,0.15)',
-              },
-              backdrop: {
-                backgroundColor: isDark ? 'rgba(0,0,0,0.6)' : 'rgba(0,0,0,0.4)',
-                backdropFilter: 'blur(6px)',
-                WebkitBackdropFilter: 'blur(6px)',
-              },
-            },
-          },
-          MuiBottomNavigation: {
-            styleOverrides: {
-              root: {
-                backgroundColor: isDark
-                  ? 'rgba(10, 10, 18, 0.95)'
-                  : 'rgba(244, 242, 238, 0.98)',
-                backdropFilter: 'blur(14px)',
-              },
-            },
-          },
-          MuiBottomNavigationAction: {
-            styleOverrides: {
-              root: {
-                color: isDark ? '#7a78a0' : '#6b6980',
-                '&.Mui-selected': {
-                  color: isDark ? '#ff2d78' : '#d6245e',
-                },
-              },
-            },
-          },
-          MuiLinearProgress: {
-            styleOverrides: {
-              root: {
-                borderRadius: 4,
-                backgroundColor: isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)',
-              },
-              bar: {
-                borderRadius: 4,
-              },
-            },
-          },
-          MuiFab: {
-            styleOverrides: {
-              root: {
-                boxShadow: isDark ? neonGlow.pink : '0 4px 16px rgba(214,36,94,0.3)',
-              },
-            },
-          },
-          MuiSwitch: {
-            styleOverrides: {
-              switchBase: {
-                '&.Mui-checked': {
-                  color: isDark ? '#ff2d78' : '#d6245e',
-                  '& + .MuiSwitch-track': {
-                    backgroundColor: isDark ? '#ff2d78' : '#d6245e',
-                  },
-                },
-              },
-            },
-          },
-          MuiAlert: {
-            styleOverrides: {
-              root: {
-                borderRadius: 12,
-              },
-            },
-          },
-        },
-      }),
-    [isDark]
-  );
+  const themeList = useMemo(() => getThemeList(), []);
+
+  const muiTheme = useMemo(() => {
+    const themeFactory = getThemeFactory(themeName, customConfig);
+    return createTheme(themeFactory(isDark));
+  }, [themeName, isDark, customConfig]);
 
   return (
     <ThemeContext.Provider
       value={{
+        themeName,
+        setThemeName,
         isDark,
+        setIsDark,
         toggleTheme,
-        paletteMode: isDark ? 'dark' : 'light',
         muiTheme,
-        neonGlow,
+        customConfig,
+        setCustomConfig,
+        themeList,
       }}
     >
       <MuiThemeProvider theme={muiTheme}>

--- a/src/shared/context/themes/cleanSlate.js
+++ b/src/shared/context/themes/cleanSlate.js
@@ -1,0 +1,370 @@
+// Clean Slate theme — minimal, clean, system sans-serif, standard MUI feel.
+// This is the default theme for new users.
+
+const systemFont = [
+  '-apple-system',
+  'BlinkMacSystemFont',
+  '"Segoe UI"',
+  'Roboto',
+  '"Helvetica Neue"',
+  'Arial',
+  'sans-serif',
+  '"Apple Color Emoji"',
+  '"Segoe UI Emoji"',
+  '"Segoe UI Symbol"',
+].join(',');
+
+export const cleanSlateTheme = (isDark) => ({
+  palette: {
+    mode: isDark ? 'dark' : 'light',
+    primary: {
+      main: isDark ? '#60a5fa' : '#2563eb',
+      light: isDark ? '#93c5fd' : '#60a5fa',
+      dark: isDark ? '#2563eb' : '#1d4ed8',
+      contrastText: '#ffffff',
+    },
+    secondary: {
+      main: isDark ? '#a78bfa' : '#7c3aed',
+      light: isDark ? '#c4b5fd' : '#a78bfa',
+      dark: isDark ? '#7c3aed' : '#6d28d9',
+      contrastText: '#ffffff',
+    },
+    success: {
+      main: isDark ? '#4ade80' : '#16a34a',
+      light: isDark ? '#86efac' : '#4ade80',
+      dark: isDark ? '#16a34a' : '#15803d',
+    },
+    warning: {
+      main: isDark ? '#fbbf24' : '#d97706',
+      light: isDark ? '#fde68a' : '#fbbf24',
+      dark: isDark ? '#d97706' : '#b45309',
+    },
+    error: {
+      main: isDark ? '#f87171' : '#dc2626',
+      light: isDark ? '#fca5a5' : '#f87171',
+      dark: isDark ? '#dc2626' : '#b91c1c',
+    },
+    info: {
+      main: isDark ? '#38bdf8' : '#0284c7',
+      light: isDark ? '#7dd3fc' : '#38bdf8',
+      dark: isDark ? '#0284c7' : '#0369a1',
+    },
+    background: {
+      default: isDark ? '#111827' : '#f9fafb',
+      paper: isDark ? '#1f2937' : '#ffffff',
+      accent: isDark ? '#374151' : '#f3f4f6',
+    },
+    text: {
+      primary: isDark ? '#f3f4f6' : '#111827',
+      secondary: isDark ? '#9ca3af' : '#6b7280',
+    },
+    divider: isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)',
+  },
+
+  shape: {
+    borderRadius: 8,
+  },
+
+  typography: {
+    fontFamily: systemFont,
+    h1: {
+      fontFamily: systemFont,
+      fontWeight: 800,
+      letterSpacing: '-0.025em',
+    },
+    h2: {
+      fontFamily: systemFont,
+      fontWeight: 700,
+      letterSpacing: '-0.025em',
+    },
+    h3: {
+      fontFamily: systemFont,
+      fontWeight: 700,
+      letterSpacing: '-0.01em',
+    },
+    h4: {
+      fontFamily: systemFont,
+      fontWeight: 700,
+    },
+    h5: {
+      fontFamily: systemFont,
+      fontWeight: 700,
+    },
+    h6: {
+      fontFamily: systemFont,
+      fontWeight: 700,
+    },
+    subtitle1: { fontWeight: 600 },
+    subtitle2: { fontWeight: 600 },
+    button: {
+      textTransform: 'none',
+      fontWeight: 600,
+      letterSpacing: 0.2,
+    },
+    body2: {
+      color: isDark ? '#9ca3af' : '#6b7280',
+    },
+  },
+
+  components: {
+    MuiButton: {
+      styleOverrides: {
+        root: {
+          borderRadius: 8,
+          transition: 'all 200ms ease',
+        },
+        contained: {
+          boxShadow: 'none',
+          '&:hover': {
+            boxShadow: isDark
+              ? '0 4px 12px rgba(96,165,250,0.25)'
+              : '0 4px 12px rgba(37,99,235,0.25)',
+          },
+        },
+        outlined: {
+          borderColor: isDark ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.12)',
+          '&:hover': {
+            borderColor: isDark ? '#60a5fa' : '#2563eb',
+          },
+        },
+      },
+    },
+
+    MuiPaper: {
+      styleOverrides: {
+        root: {
+          borderRadius: 12,
+          backgroundImage: 'none',
+          transition: 'box-shadow 200ms ease, border-color 200ms ease',
+          ...(isDark && {
+            backgroundColor: '#1f2937',
+            border: '1px solid rgba(255,255,255,0.06)',
+          }),
+        },
+      },
+    },
+
+    MuiCard: {
+      defaultProps: {
+        elevation: 0,
+      },
+      styleOverrides: {
+        root: {
+          border: `1px solid ${isDark ? 'rgba(255,255,255,0.06)' : '#e5e7eb'}`,
+          boxShadow: isDark
+            ? '0 1px 3px rgba(0,0,0,0.3)'
+            : '0 1px 3px rgba(0,0,0,0.06), 0 1px 2px rgba(0,0,0,0.04)',
+          transition: 'all 200ms ease',
+          '&:hover': {
+            borderColor: isDark ? 'rgba(255,255,255,0.1)' : '#d1d5db',
+            boxShadow: isDark
+              ? '0 4px 12px rgba(0,0,0,0.4)'
+              : '0 4px 12px rgba(0,0,0,0.08)',
+          },
+        },
+      },
+    },
+
+    MuiCardContent: {
+      styleOverrides: {
+        root: ({ theme: t }) => ({
+          padding: '16px 16px 12px',
+          [t.breakpoints.up('sm')]: {
+            padding: '20px 20px 16px',
+          },
+          '&:last-child': {
+            paddingBottom: 16,
+            [t.breakpoints.up('sm')]: {
+              paddingBottom: 20,
+            },
+          },
+        }),
+      },
+    },
+
+    MuiAppBar: {
+      styleOverrides: {
+        root: {
+          backgroundColor: isDark
+            ? 'rgba(17, 24, 39, 0.95)'
+            : 'rgba(249, 250, 251, 0.95)',
+          backdropFilter: 'blur(12px)',
+          boxShadow: 'none',
+          borderBottom: isDark
+            ? '1px solid rgba(255,255,255,0.06)'
+            : '1px solid rgba(0,0,0,0.06)',
+        },
+      },
+    },
+
+    MuiTab: {
+      styleOverrides: {
+        root: {
+          transition: 'all 200ms ease',
+          '&.Mui-selected': {
+            color: isDark ? '#60a5fa' : '#2563eb',
+          },
+        },
+      },
+    },
+
+    MuiTabs: {
+      styleOverrides: {
+        indicator: {
+          backgroundColor: isDark ? '#60a5fa' : '#2563eb',
+          height: 3,
+          borderRadius: '3px 3px 0 0',
+        },
+      },
+    },
+
+    MuiTextField: {
+      styleOverrides: {
+        root: {
+          '& .MuiOutlinedInput-root': {
+            '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+              borderColor: isDark ? '#60a5fa' : '#2563eb',
+            },
+          },
+        },
+      },
+    },
+
+    MuiAccordion: {
+      styleOverrides: {
+        root: {
+          backgroundColor: isDark ? '#1f2937' : '#ffffff',
+          '&::before': {
+            display: 'none',
+          },
+        },
+      },
+    },
+
+    MuiDialog: {
+      styleOverrides: {
+        paper: {
+          backgroundColor: isDark ? '#1f2937' : '#ffffff',
+          border: isDark ? '1px solid rgba(255,255,255,0.06)' : 'none',
+          boxShadow: isDark
+            ? '0 24px 48px rgba(0,0,0,0.5)'
+            : '0 24px 48px rgba(0,0,0,0.12)',
+        },
+      },
+    },
+
+    MuiBackdrop: {
+      styleOverrides: {
+        root: {
+          backgroundColor: isDark
+            ? 'rgba(0, 0, 0, 0.5)'
+            : 'rgba(0, 0, 0, 0.3)',
+          backdropFilter: 'blur(4px)',
+          WebkitBackdropFilter: 'blur(4px)',
+        },
+      },
+    },
+
+    MuiBottomNavigation: {
+      styleOverrides: {
+        root: {
+          backgroundColor: isDark
+            ? 'rgba(17, 24, 39, 0.95)'
+            : 'rgba(249, 250, 251, 0.98)',
+          backdropFilter: 'blur(12px)',
+        },
+      },
+    },
+
+    MuiBottomNavigationAction: {
+      styleOverrides: {
+        root: {
+          color: isDark ? '#9ca3af' : '#6b7280',
+          '&.Mui-selected': {
+            color: isDark ? '#60a5fa' : '#2563eb',
+          },
+        },
+      },
+    },
+
+    MuiLinearProgress: {
+      styleOverrides: {
+        root: {
+          borderRadius: 4,
+          backgroundColor: isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)',
+        },
+        bar: {
+          borderRadius: 4,
+        },
+      },
+    },
+
+    MuiFab: {
+      styleOverrides: {
+        root: {
+          boxShadow: isDark
+            ? '0 4px 14px rgba(96,165,250,0.3)'
+            : '0 4px 14px rgba(37,99,235,0.25)',
+        },
+      },
+    },
+
+    MuiSwitch: {
+      styleOverrides: {
+        switchBase: {
+          '&.Mui-checked': {
+            color: isDark ? '#60a5fa' : '#2563eb',
+            '& + .MuiSwitch-track': {
+              backgroundColor: isDark ? '#60a5fa' : '#2563eb',
+            },
+          },
+        },
+      },
+    },
+
+    MuiAlert: {
+      styleOverrides: {
+        root: {
+          borderRadius: 8,
+        },
+      },
+    },
+
+    MuiChip: {
+      styleOverrides: {
+        outlined: {
+          borderColor: isDark ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.12)',
+        },
+      },
+    },
+  },
+
+  // Custom namespace for app-specific tokens
+  custom: {
+    glowStyle: 'none',
+    macroColors: {
+      calories: '#f59e0b',
+      protein: '#3b82f6',
+      carbs: '#ef4444',
+      fat: '#8b5cf6',
+    },
+    cssClass: 'theme-clean-slate',
+    toast: {
+      className: 'toast-clean-slate',
+      success: {
+        className: 'toast-clean-slate toast-clean-slate-success',
+        iconTheme: {
+          primary: isDark ? '#4ade80' : '#16a34a',
+          secondary: isDark ? '#1f2937' : '#ffffff',
+        },
+      },
+      error: {
+        className: 'toast-clean-slate toast-clean-slate-error',
+        iconTheme: {
+          primary: isDark ? '#f87171' : '#dc2626',
+          secondary: isDark ? '#1f2937' : '#ffffff',
+        },
+      },
+    },
+  },
+});

--- a/src/shared/context/themes/customTheme.js
+++ b/src/shared/context/themes/customTheme.js
@@ -1,0 +1,519 @@
+// Custom theme builder — generates a full MUI theme from user configuration.
+// Supports configurable primary/accent colors, font pairs, border radius, and glow styles.
+
+// ─── Font pair presets ────────────────────────────────────────────────────────
+
+export const FONT_PAIRS = {
+  system: {
+    label: 'System Default',
+    body: 'system-ui, -apple-system, "Segoe UI", Roboto, sans-serif',
+    heading: 'system-ui, -apple-system, "Segoe UI", Roboto, sans-serif',
+  },
+  interDm: {
+    label: 'Inter + DM Sans',
+    body: '"Inter", system-ui, sans-serif',
+    heading: '"DM Sans", system-ui, sans-serif',
+  },
+  poppinsNunito: {
+    label: 'Poppins + Nunito',
+    body: '"Nunito", system-ui, sans-serif',
+    heading: '"Poppins", system-ui, sans-serif',
+  },
+  spaceIbm: {
+    label: 'Space Grotesk + IBM Plex',
+    body: '"IBM Plex Sans", system-ui, sans-serif',
+    heading: '"Space Grotesk", system-ui, sans-serif',
+  },
+  merriweatherLato: {
+    label: 'Merriweather Sans + Lato',
+    body: '"Lato", system-ui, sans-serif',
+    heading: '"Merriweather Sans", system-ui, sans-serif',
+  },
+  orbitronUrbanist: {
+    label: 'Orbitron + Urbanist',
+    body: '"Urbanist", system-ui, sans-serif',
+    heading: '"Orbitron", sans-serif',
+  },
+};
+
+// ─── Default configuration ────────────────────────────────────────────────────
+
+export const DEFAULT_CUSTOM_CONFIG = {
+  primaryColor: '#2563eb',
+  accentColor: '#f59e0b',
+  fontPair: 'system',
+  borderRadius: 12,
+  glowStyle: 'none',
+};
+
+// ─── Color helpers ────────────────────────────────────────────────────────────
+
+/** Parse a hex color string to {r, g, b}. Supports #RGB and #RRGGBB. */
+const hexToRgb = (hex) => {
+  let h = hex.replace('#', '');
+  if (h.length === 3) h = h[0] + h[0] + h[1] + h[1] + h[2] + h[2];
+  const n = parseInt(h, 16);
+  return { r: (n >> 16) & 255, g: (n >> 8) & 255, b: n & 255 };
+};
+
+/** Convert {r, g, b} back to a hex string. */
+const rgbToHex = ({ r, g, b }) =>
+  '#' + [r, g, b].map((c) => Math.max(0, Math.min(255, Math.round(c))).toString(16).padStart(2, '0')).join('');
+
+/** Mix a color toward white (amount 0-1). */
+const lighten = (hex, amount) => {
+  const { r, g, b } = hexToRgb(hex);
+  return rgbToHex({
+    r: r + (255 - r) * amount,
+    g: g + (255 - g) * amount,
+    b: b + (255 - b) * amount,
+  });
+};
+
+/** Mix a color toward black (amount 0-1). */
+const darken = (hex, amount) => {
+  const { r, g, b } = hexToRgb(hex);
+  return rgbToHex({
+    r: r * (1 - amount),
+    g: g * (1 - amount),
+    b: b * (1 - amount),
+  });
+};
+
+/** Convert hex to an rgba() string. */
+const hexToRgba = (hex, alpha) => {
+  const { r, g, b } = hexToRgb(hex);
+  return `rgba(${r},${g},${b},${alpha})`;
+};
+
+// ─── Glow presets ─────────────────────────────────────────────────────────────
+
+const buildGlows = (primaryMain, glowStyle) => {
+  if (glowStyle === 'neon') {
+    return {
+      buttonContained: `0 0 20px ${hexToRgba(primaryMain, 0.3)}, 0 0 60px ${hexToRgba(primaryMain, 0.1)}`,
+      buttonContainedHover: `0 0 30px ${hexToRgba(primaryMain, 0.4)}, 0 0 80px ${hexToRgba(primaryMain, 0.15)}`,
+      buttonOutlinedHover: `0 0 12px ${hexToRgba(primaryMain, 0.2)}`,
+      cardHover: `0 4px 30px rgba(0,0,0,0.4), 0 0 20px ${hexToRgba(primaryMain, 0.1)}`,
+      fab: `0 0 20px ${hexToRgba(primaryMain, 0.3)}, 0 0 60px ${hexToRgba(primaryMain, 0.1)}`,
+      tabIndicator: `0 0 10px ${hexToRgba(primaryMain, 0.5)}`,
+      textFieldFocus: `0 0 12px ${hexToRgba(primaryMain, 0.2)}`,
+    };
+  }
+  if (glowStyle === 'soft') {
+    return {
+      buttonContained: 'none',
+      buttonContainedHover: `0 4px 20px ${hexToRgba(primaryMain, 0.3)}`,
+      buttonOutlinedHover: `0 0 12px ${hexToRgba(primaryMain, 0.15)}`,
+      cardHover: `0 6px 24px rgba(0,0,0,0.4), 0 0 16px ${hexToRgba(primaryMain, 0.08)}`,
+      fab: `0 4px 14px ${hexToRgba(primaryMain, 0.3)}`,
+      tabIndicator: 'none',
+      textFieldFocus: 'none',
+    };
+  }
+  // 'none' — no glow effects
+  return {
+    buttonContained: 'none',
+    buttonContainedHover: 'none',
+    buttonOutlinedHover: 'none',
+    cardHover: null, // use default shadow
+    fab: 'none',
+    tabIndicator: 'none',
+    textFieldFocus: 'none',
+  };
+};
+
+// ─── Theme factory ────────────────────────────────────────────────────────────
+
+export const createCustomTheme = (isDark, config = DEFAULT_CUSTOM_CONFIG) => {
+  const {
+    primaryColor = DEFAULT_CUSTOM_CONFIG.primaryColor,
+    accentColor = DEFAULT_CUSTOM_CONFIG.accentColor,
+    fontPair = DEFAULT_CUSTOM_CONFIG.fontPair,
+    borderRadius = DEFAULT_CUSTOM_CONFIG.borderRadius,
+    glowStyle = DEFAULT_CUSTOM_CONFIG.glowStyle,
+  } = config;
+
+  // Resolve primary & secondary color sets
+  const primary = {
+    main: isDark ? lighten(primaryColor, 0.2) : primaryColor,
+    light: isDark ? lighten(primaryColor, 0.4) : lighten(primaryColor, 0.2),
+    dark: isDark ? primaryColor : darken(primaryColor, 0.15),
+    contrastText: '#ffffff',
+  };
+  const secondary = {
+    main: isDark ? lighten(accentColor, 0.15) : accentColor,
+    light: isDark ? lighten(accentColor, 0.35) : lighten(accentColor, 0.2),
+    dark: isDark ? accentColor : darken(accentColor, 0.15),
+    contrastText: '#ffffff',
+  };
+
+  // Resolve fonts (fallback to system if key not found)
+  const fonts = FONT_PAIRS[fontPair] || FONT_PAIRS.system;
+  const bodyFont = fonts.body;
+  const headingFont = fonts.heading;
+
+  // Build glow effects
+  const glows = buildGlows(primary.main, isDark ? glowStyle : 'none');
+  // In light mode, use subtle standard shadows instead of colored glows
+  const lightButtonHover = `0 4px 12px ${hexToRgba(primaryColor, 0.25)}`;
+  const lightFab = `0 4px 14px ${hexToRgba(primaryColor, 0.25)}`;
+
+  // Standard semantic colors (same as Clean Slate)
+  const success = {
+    main: isDark ? '#4ade80' : '#16a34a',
+    light: isDark ? '#86efac' : '#4ade80',
+    dark: isDark ? '#16a34a' : '#15803d',
+  };
+  const warning = {
+    main: isDark ? '#fbbf24' : '#d97706',
+    light: isDark ? '#fde68a' : '#fbbf24',
+    dark: isDark ? '#d97706' : '#b45309',
+  };
+  const error = {
+    main: isDark ? '#f87171' : '#dc2626',
+    light: isDark ? '#fca5a5' : '#f87171',
+    dark: isDark ? '#dc2626' : '#b91c1c',
+  };
+  const info = {
+    main: isDark ? '#38bdf8' : '#0284c7',
+    light: isDark ? '#7dd3fc' : '#38bdf8',
+    dark: isDark ? '#0284c7' : '#0369a1',
+  };
+
+  // Backgrounds & text — sensible defaults
+  const background = {
+    default: isDark ? '#111827' : '#f9fafb',
+    paper: isDark ? '#1f2937' : '#ffffff',
+    accent: isDark ? '#374151' : '#f3f4f6',
+  };
+  const text = {
+    primary: isDark ? '#f3f4f6' : '#111827',
+    secondary: isDark ? '#9ca3af' : '#6b7280',
+  };
+  const divider = isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)';
+
+  // Card hover shadow depends on glow style
+  const cardHoverShadow = glows.cardHover
+    ? glows.cardHover
+    : isDark
+      ? '0 4px 12px rgba(0,0,0,0.4)'
+      : '0 4px 12px rgba(0,0,0,0.08)';
+
+  return {
+    palette: {
+      mode: isDark ? 'dark' : 'light',
+      primary,
+      secondary,
+      success,
+      warning,
+      error,
+      info,
+      background,
+      text,
+      divider,
+    },
+
+    shape: {
+      borderRadius,
+    },
+
+    typography: {
+      fontFamily: bodyFont,
+      h1: {
+        fontFamily: headingFont,
+        fontWeight: 800,
+        letterSpacing: '-0.025em',
+      },
+      h2: {
+        fontFamily: headingFont,
+        fontWeight: 700,
+        letterSpacing: '-0.025em',
+      },
+      h3: {
+        fontFamily: headingFont,
+        fontWeight: 700,
+        letterSpacing: '-0.01em',
+      },
+      h4: {
+        fontFamily: headingFont,
+        fontWeight: 700,
+      },
+      h5: {
+        fontFamily: bodyFont,
+        fontWeight: 700,
+      },
+      h6: {
+        fontFamily: bodyFont,
+        fontWeight: 700,
+      },
+      subtitle1: { fontWeight: 600 },
+      subtitle2: { fontWeight: 600 },
+      button: {
+        textTransform: 'none',
+        fontWeight: 600,
+        letterSpacing: 0.2,
+      },
+      body2: {
+        color: text.secondary,
+      },
+    },
+
+    components: {
+      MuiButton: {
+        styleOverrides: {
+          root: {
+            borderRadius,
+            transition: 'all 200ms ease',
+          },
+          contained: {
+            boxShadow: isDark ? glows.buttonContained : 'none',
+            '&:hover': {
+              boxShadow: isDark ? glows.buttonContainedHover : lightButtonHover,
+            },
+          },
+          outlined: {
+            borderColor: isDark ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.12)',
+            '&:hover': {
+              borderColor: primary.main,
+              boxShadow: isDark ? glows.buttonOutlinedHover : 'none',
+            },
+          },
+        },
+      },
+
+      MuiPaper: {
+        styleOverrides: {
+          root: {
+            borderRadius: borderRadius + 4,
+            backgroundImage: 'none',
+            transition: 'box-shadow 200ms ease, border-color 200ms ease',
+            ...(isDark && {
+              backgroundColor: background.paper,
+              border: '1px solid rgba(255,255,255,0.06)',
+            }),
+          },
+        },
+      },
+
+      MuiCard: {
+        defaultProps: {
+          elevation: 0,
+        },
+        styleOverrides: {
+          root: {
+            border: `1px solid ${isDark ? 'rgba(255,255,255,0.06)' : '#e5e7eb'}`,
+            boxShadow: isDark
+              ? '0 1px 3px rgba(0,0,0,0.3)'
+              : '0 1px 3px rgba(0,0,0,0.06), 0 1px 2px rgba(0,0,0,0.04)',
+            transition: 'all 200ms ease',
+            '&:hover': {
+              borderColor: isDark ? 'rgba(255,255,255,0.1)' : '#d1d5db',
+              boxShadow: cardHoverShadow,
+            },
+          },
+        },
+      },
+
+      MuiCardContent: {
+        styleOverrides: {
+          root: ({ theme: t }) => ({
+            padding: '16px 16px 12px',
+            [t.breakpoints.up('sm')]: {
+              padding: '20px 20px 16px',
+            },
+            '&:last-child': {
+              paddingBottom: 16,
+              [t.breakpoints.up('sm')]: {
+                paddingBottom: 20,
+              },
+            },
+          }),
+        },
+      },
+
+      MuiAppBar: {
+        styleOverrides: {
+          root: {
+            backgroundColor: isDark
+              ? 'rgba(17, 24, 39, 0.95)'
+              : 'rgba(249, 250, 251, 0.95)',
+            backdropFilter: 'blur(12px)',
+            boxShadow: 'none',
+            borderBottom: isDark
+              ? '1px solid rgba(255,255,255,0.06)'
+              : '1px solid rgba(0,0,0,0.06)',
+          },
+        },
+      },
+
+      MuiTab: {
+        styleOverrides: {
+          root: {
+            transition: 'all 200ms ease',
+            '&.Mui-selected': {
+              color: primary.main,
+            },
+          },
+        },
+      },
+
+      MuiTabs: {
+        styleOverrides: {
+          indicator: {
+            backgroundColor: primary.main,
+            height: 3,
+            borderRadius: '3px 3px 0 0',
+            ...(isDark && glows.tabIndicator !== 'none' && {
+              boxShadow: glows.tabIndicator,
+            }),
+          },
+        },
+      },
+
+      MuiTextField: {
+        styleOverrides: {
+          root: {
+            '& .MuiOutlinedInput-root': {
+              '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+                borderColor: primary.main,
+                ...(isDark && glows.textFieldFocus !== 'none' && {
+                  boxShadow: glows.textFieldFocus,
+                }),
+              },
+            },
+          },
+        },
+      },
+
+      MuiAccordion: {
+        styleOverrides: {
+          root: {
+            backgroundColor: background.paper,
+            '&::before': {
+              display: 'none',
+            },
+          },
+        },
+      },
+
+      MuiDialog: {
+        styleOverrides: {
+          paper: {
+            backgroundColor: background.paper,
+            border: isDark ? '1px solid rgba(255,255,255,0.06)' : 'none',
+            boxShadow: isDark
+              ? '0 24px 48px rgba(0,0,0,0.5)'
+              : '0 24px 48px rgba(0,0,0,0.12)',
+          },
+        },
+      },
+
+      MuiBackdrop: {
+        styleOverrides: {
+          root: {
+            backgroundColor: isDark
+              ? 'rgba(0, 0, 0, 0.5)'
+              : 'rgba(0, 0, 0, 0.3)',
+            backdropFilter: 'blur(4px)',
+            WebkitBackdropFilter: 'blur(4px)',
+          },
+        },
+      },
+
+      MuiBottomNavigation: {
+        styleOverrides: {
+          root: {
+            backgroundColor: isDark
+              ? 'rgba(17, 24, 39, 0.95)'
+              : 'rgba(249, 250, 251, 0.98)',
+            backdropFilter: 'blur(12px)',
+          },
+        },
+      },
+
+      MuiBottomNavigationAction: {
+        styleOverrides: {
+          root: {
+            color: text.secondary,
+            '&.Mui-selected': {
+              color: primary.main,
+            },
+          },
+        },
+      },
+
+      MuiLinearProgress: {
+        styleOverrides: {
+          root: {
+            borderRadius: Math.min(borderRadius, 4),
+            backgroundColor: isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)',
+          },
+          bar: {
+            borderRadius: Math.min(borderRadius, 4),
+          },
+        },
+      },
+
+      MuiFab: {
+        styleOverrides: {
+          root: {
+            boxShadow: isDark ? glows.fab : lightFab,
+          },
+        },
+      },
+
+      MuiSwitch: {
+        styleOverrides: {
+          switchBase: {
+            '&.Mui-checked': {
+              color: primary.main,
+              '& + .MuiSwitch-track': {
+                backgroundColor: primary.main,
+              },
+            },
+          },
+        },
+      },
+
+      MuiAlert: {
+        styleOverrides: {
+          root: {
+            borderRadius,
+          },
+        },
+      },
+
+      MuiChip: {
+        styleOverrides: {
+          outlined: {
+            borderColor: isDark ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.12)',
+          },
+        },
+      },
+    },
+
+    // Custom namespace for app-specific tokens
+    custom: {
+      glowStyle,
+      macroColors: {
+        calories: secondary.main,
+        protein: primary.main,
+        carbs: error.main,
+        fat: info.main,
+      },
+      cssClass: 'theme-custom',
+      toast: {
+        className: '',
+        success: {
+          primary: success.main,
+          secondary: background.paper,
+        },
+        error: {
+          primary: error.main,
+          secondary: background.paper,
+        },
+      },
+    },
+  };
+};

--- a/src/shared/context/themes/forestFloor.js
+++ b/src/shared/context/themes/forestFloor.js
@@ -1,0 +1,353 @@
+// Forest Floor theme — earthy, natural, warm with matte surfaces and warm-toned shadows.
+
+const bodyFont = '"Lato", system-ui, sans-serif';
+const headingFont = '"Merriweather Sans", system-ui, sans-serif';
+
+export const forestFloorTheme = (isDark) => ({
+  palette: {
+    mode: isDark ? 'dark' : 'light',
+    primary: {
+      main: isDark ? '#8bc34a' : '#558b2f',
+      light: isDark ? '#aed581' : '#8bc34a',
+      dark: isDark ? '#558b2f' : '#33691e',
+      contrastText: '#ffffff',
+    },
+    secondary: {
+      main: isDark ? '#ffd54f' : '#d4a017',
+      light: isDark ? '#ffe082' : '#ffd54f',
+      dark: isDark ? '#d4a017' : '#b8860b',
+      contrastText: isDark ? '#1a1a14' : '#ffffff',
+    },
+    success: {
+      main: isDark ? '#66bb6a' : '#2e7d32',
+      light: isDark ? '#a5d6a7' : '#66bb6a',
+      dark: isDark ? '#2e7d32' : '#1b5e20',
+    },
+    warning: {
+      main: isDark ? '#ffb74d' : '#e65100',
+      light: isDark ? '#ffe0b2' : '#ffb74d',
+      dark: isDark ? '#e65100' : '#bf360c',
+    },
+    error: {
+      main: isDark ? '#ef5350' : '#c62828',
+      light: isDark ? '#ef9a9a' : '#ef5350',
+      dark: isDark ? '#c62828' : '#b71c1c',
+    },
+    info: {
+      main: isDark ? '#4fc3f7' : '#0277bd',
+      light: isDark ? '#81d4fa' : '#4fc3f7',
+      dark: isDark ? '#0277bd' : '#01579b',
+    },
+    background: {
+      default: isDark ? '#1a1a14' : '#faf6f1',
+      paper: isDark ? '#2a2a20' : '#ffffff',
+      accent: isDark ? '#3a3a2e' : '#f0ebe3',
+    },
+    text: {
+      primary: isDark ? '#ede8df' : '#1a1a14',
+      secondary: isDark ? '#9e9a8e' : '#6b6560',
+    },
+    divider: isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)',
+  },
+
+  shape: {
+    borderRadius: 8,
+  },
+
+  typography: {
+    fontFamily: bodyFont,
+    h1: {
+      fontFamily: headingFont,
+      fontWeight: 800,
+      letterSpacing: '-0.02em',
+    },
+    h2: {
+      fontFamily: headingFont,
+      fontWeight: 700,
+      letterSpacing: '-0.02em',
+    },
+    h3: {
+      fontFamily: headingFont,
+      fontWeight: 700,
+      letterSpacing: '-0.01em',
+    },
+    h4: {
+      fontFamily: headingFont,
+      fontWeight: 700,
+    },
+    h5: {
+      fontFamily: bodyFont,
+      fontWeight: 700,
+    },
+    h6: {
+      fontFamily: bodyFont,
+      fontWeight: 700,
+    },
+    subtitle1: { fontWeight: 600 },
+    subtitle2: { fontWeight: 600 },
+    button: {
+      textTransform: 'none',
+      fontWeight: 600,
+      letterSpacing: 0.2,
+    },
+    body2: {
+      color: isDark ? '#9e9a8e' : '#6b6560',
+    },
+  },
+
+  components: {
+    MuiButton: {
+      styleOverrides: {
+        root: {
+          borderRadius: 8,
+          transition: 'all 200ms ease',
+        },
+        contained: {
+          boxShadow: 'none',
+          '&:hover': {
+            boxShadow: isDark
+              ? '0 4px 12px rgba(139,195,74,0.2)'
+              : '0 4px 12px rgba(85,139,47,0.2)',
+          },
+        },
+        outlined: {
+          borderColor: isDark ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.12)',
+          '&:hover': {
+            borderColor: isDark ? '#8bc34a' : '#558b2f',
+          },
+        },
+      },
+    },
+
+    MuiPaper: {
+      styleOverrides: {
+        root: {
+          borderRadius: 10,
+          backgroundImage: 'none',
+          transition: 'box-shadow 200ms ease, border-color 200ms ease',
+          ...(isDark && {
+            backgroundColor: '#2a2a20',
+            border: '1px solid rgba(255,255,255,0.06)',
+          }),
+        },
+      },
+    },
+
+    MuiCard: {
+      defaultProps: {
+        elevation: 0,
+      },
+      styleOverrides: {
+        root: {
+          border: `1px solid ${isDark ? 'rgba(255,255,255,0.06)' : '#e0dbd3'}`,
+          boxShadow: isDark
+            ? '0 2px 6px rgba(0,0,0,0.3)'
+            : '0 2px 6px rgba(100,80,50,0.06), 0 1px 2px rgba(100,80,50,0.04)',
+          transition: 'all 200ms ease',
+          '&:hover': {
+            borderColor: isDark ? 'rgba(255,255,255,0.1)' : '#ccc5ba',
+            boxShadow: isDark
+              ? '0 4px 16px rgba(0,0,0,0.4)'
+              : '0 4px 16px rgba(100,80,50,0.1)',
+          },
+        },
+      },
+    },
+
+    MuiCardContent: {
+      styleOverrides: {
+        root: ({ theme: t }) => ({
+          padding: '16px 16px 12px',
+          [t.breakpoints.up('sm')]: {
+            padding: '20px 20px 16px',
+          },
+          '&:last-child': {
+            paddingBottom: 16,
+            [t.breakpoints.up('sm')]: {
+              paddingBottom: 20,
+            },
+          },
+        }),
+      },
+    },
+
+    MuiAppBar: {
+      styleOverrides: {
+        root: {
+          backgroundColor: isDark
+            ? 'rgba(26, 26, 20, 0.95)'
+            : 'rgba(250, 246, 241, 0.95)',
+          backdropFilter: 'blur(12px)',
+          boxShadow: 'none',
+          borderBottom: isDark
+            ? '1px solid rgba(255,255,255,0.06)'
+            : '1px solid rgba(0,0,0,0.06)',
+        },
+      },
+    },
+
+    MuiTab: {
+      styleOverrides: {
+        root: {
+          transition: 'all 200ms ease',
+          '&.Mui-selected': {
+            color: isDark ? '#8bc34a' : '#558b2f',
+          },
+        },
+      },
+    },
+
+    MuiTabs: {
+      styleOverrides: {
+        indicator: {
+          backgroundColor: isDark ? '#8bc34a' : '#558b2f',
+          height: 3,
+          borderRadius: '3px 3px 0 0',
+        },
+      },
+    },
+
+    MuiTextField: {
+      styleOverrides: {
+        root: {
+          '& .MuiOutlinedInput-root': {
+            '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+              borderColor: isDark ? '#8bc34a' : '#558b2f',
+            },
+          },
+        },
+      },
+    },
+
+    MuiAccordion: {
+      styleOverrides: {
+        root: {
+          backgroundColor: isDark ? '#2a2a20' : '#ffffff',
+          '&::before': {
+            display: 'none',
+          },
+        },
+      },
+    },
+
+    MuiDialog: {
+      styleOverrides: {
+        paper: {
+          backgroundColor: isDark ? '#2a2a20' : '#ffffff',
+          border: isDark ? '1px solid rgba(255,255,255,0.06)' : 'none',
+          boxShadow: isDark
+            ? '0 24px 48px rgba(0,0,0,0.5)'
+            : '0 24px 48px rgba(0,0,0,0.12)',
+        },
+      },
+    },
+
+    MuiBackdrop: {
+      styleOverrides: {
+        root: {
+          backgroundColor: isDark
+            ? 'rgba(0, 0, 0, 0.5)'
+            : 'rgba(0, 0, 0, 0.3)',
+          backdropFilter: 'blur(4px)',
+          WebkitBackdropFilter: 'blur(4px)',
+        },
+      },
+    },
+
+    MuiBottomNavigation: {
+      styleOverrides: {
+        root: {
+          backgroundColor: isDark
+            ? 'rgba(26, 26, 20, 0.95)'
+            : 'rgba(250, 246, 241, 0.98)',
+          backdropFilter: 'blur(12px)',
+        },
+      },
+    },
+
+    MuiBottomNavigationAction: {
+      styleOverrides: {
+        root: {
+          color: isDark ? '#9e9a8e' : '#6b6560',
+          '&.Mui-selected': {
+            color: isDark ? '#8bc34a' : '#558b2f',
+          },
+        },
+      },
+    },
+
+    MuiLinearProgress: {
+      styleOverrides: {
+        root: {
+          borderRadius: 4,
+          backgroundColor: isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)',
+        },
+        bar: {
+          borderRadius: 4,
+        },
+      },
+    },
+
+    MuiFab: {
+      styleOverrides: {
+        root: {
+          boxShadow: isDark
+            ? '0 4px 14px rgba(139,195,74,0.3)'
+            : '0 4px 14px rgba(85,139,47,0.25)',
+        },
+      },
+    },
+
+    MuiSwitch: {
+      styleOverrides: {
+        switchBase: {
+          '&.Mui-checked': {
+            color: isDark ? '#8bc34a' : '#558b2f',
+            '& + .MuiSwitch-track': {
+              backgroundColor: isDark ? '#8bc34a' : '#558b2f',
+            },
+          },
+        },
+      },
+    },
+
+    MuiAlert: {
+      styleOverrides: {
+        root: {
+          borderRadius: 8,
+        },
+      },
+    },
+
+    MuiChip: {
+      styleOverrides: {
+        outlined: {
+          borderColor: isDark ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.12)',
+        },
+      },
+    },
+  },
+
+  // Custom namespace for app-specific tokens
+  custom: {
+    glowStyle: 'none',
+    macroColors: {
+      calories: '#e6a817',
+      protein: '#2e7d32',
+      carbs: '#c62828',
+      fat: '#6a1b9a',
+    },
+    cssClass: 'theme-forest-floor',
+    toast: {
+      className: '',
+      success: {
+        primary: isDark ? '#66bb6a' : '#2e7d32',
+        secondary: isDark ? '#2a2a20' : '#ffffff',
+      },
+      error: {
+        primary: isDark ? '#ef5350' : '#c62828',
+        secondary: isDark ? '#2a2a20' : '#ffffff',
+      },
+    },
+  },
+});

--- a/src/shared/context/themes/index.js
+++ b/src/shared/context/themes/index.js
@@ -7,6 +7,7 @@ import { oceanBreezeTheme } from './oceanBreeze';
 import { forestFloorTheme } from './forestFloor';
 import { lavenderHazeTheme } from './lavenderHaze';
 import { midnightEmberTheme } from './midnightEmber';
+import { createCustomTheme } from './customTheme';
 
 export const THEME_REGISTRY = {
   cleanSlate: {
@@ -81,12 +82,25 @@ export const THEME_REGISTRY = {
       bgDark: '#0c0a09',
     },
   },
+  custom: {
+    id: 'custom',
+    label: 'Custom',
+    description: 'Design your own',
+    factory: null, // handled specially
+    preview: null, // computed from user config
+  },
 };
 
 export const DEFAULT_THEME = 'cleanSlate';
 
-export const getThemeFactory = (themeName) =>
-  THEME_REGISTRY[themeName]?.factory ?? THEME_REGISTRY[DEFAULT_THEME].factory;
+export const getThemeFactory = (themeName, customConfig) => {
+  if (themeName === 'custom') {
+    return (isDark) => createCustomTheme(isDark, customConfig);
+  }
+  return THEME_REGISTRY[themeName]?.factory ?? THEME_REGISTRY[DEFAULT_THEME].factory;
+};
 
 export const getThemeList = () =>
   Object.values(THEME_REGISTRY);
+
+export { createCustomTheme, FONT_PAIRS, DEFAULT_CUSTOM_CONFIG } from './customTheme';

--- a/src/shared/context/themes/index.js
+++ b/src/shared/context/themes/index.js
@@ -2,6 +2,7 @@
 // Each entry maps a theme ID to its metadata and factory function.
 
 import { cleanSlateTheme } from './cleanSlate';
+import { tokyoNightsTheme } from './tokyoNights';
 
 export const THEME_REGISTRY = {
   cleanSlate: {
@@ -14,6 +15,18 @@ export const THEME_REGISTRY = {
       secondary: '#7c3aed',
       bg: '#f9fafb',
       bgDark: '#111827',
+    },
+  },
+  tokyoNights: {
+    id: 'tokyoNights',
+    label: 'Tokyo Nights',
+    description: 'Cyberpunk neon',
+    factory: tokyoNightsTheme,
+    preview: {
+      primary: '#ff2d78',
+      secondary: '#00e5ff',
+      bg: '#f4f2ee',
+      bgDark: '#0a0a12',
     },
   },
 };

--- a/src/shared/context/themes/index.js
+++ b/src/shared/context/themes/index.js
@@ -1,0 +1,27 @@
+// Theme registry — central catalogue of all available themes.
+// Each entry maps a theme ID to its metadata and factory function.
+
+import { cleanSlateTheme } from './cleanSlate';
+
+export const THEME_REGISTRY = {
+  cleanSlate: {
+    id: 'cleanSlate',
+    label: 'Clean Slate',
+    description: 'Minimal and clean',
+    factory: cleanSlateTheme,
+    preview: {
+      primary: '#2563eb',
+      secondary: '#7c3aed',
+      bg: '#f9fafb',
+      bgDark: '#111827',
+    },
+  },
+};
+
+export const DEFAULT_THEME = 'cleanSlate';
+
+export const getThemeFactory = (themeName) =>
+  THEME_REGISTRY[themeName]?.factory ?? THEME_REGISTRY[DEFAULT_THEME].factory;
+
+export const getThemeList = () =>
+  Object.values(THEME_REGISTRY);

--- a/src/shared/context/themes/index.js
+++ b/src/shared/context/themes/index.js
@@ -3,6 +3,10 @@
 
 import { cleanSlateTheme } from './cleanSlate';
 import { tokyoNightsTheme } from './tokyoNights';
+import { oceanBreezeTheme } from './oceanBreeze';
+import { forestFloorTheme } from './forestFloor';
+import { lavenderHazeTheme } from './lavenderHaze';
+import { midnightEmberTheme } from './midnightEmber';
 
 export const THEME_REGISTRY = {
   cleanSlate: {
@@ -27,6 +31,54 @@ export const THEME_REGISTRY = {
       secondary: '#00e5ff',
       bg: '#f4f2ee',
       bgDark: '#0a0a12',
+    },
+  },
+  oceanBreeze: {
+    id: 'oceanBreeze',
+    label: 'Ocean Breeze',
+    description: 'Calm and coastal',
+    factory: oceanBreezeTheme,
+    preview: {
+      primary: '#0d9488',
+      secondary: '#f97316',
+      bg: '#f0fdfa',
+      bgDark: '#0f172a',
+    },
+  },
+  forestFloor: {
+    id: 'forestFloor',
+    label: 'Forest Floor',
+    description: 'Earthy and natural',
+    factory: forestFloorTheme,
+    preview: {
+      primary: '#558b2f',
+      secondary: '#d4a017',
+      bg: '#faf6f1',
+      bgDark: '#1a1a14',
+    },
+  },
+  lavenderHaze: {
+    id: 'lavenderHaze',
+    label: 'Lavender Haze',
+    description: 'Soft and dreamy',
+    factory: lavenderHazeTheme,
+    preview: {
+      primary: '#7c3aed',
+      secondary: '#e11d48',
+      bg: '#faf5ff',
+      bgDark: '#0f0720',
+    },
+  },
+  midnightEmber: {
+    id: 'midnightEmber',
+    label: 'Midnight Ember',
+    description: 'Bold and industrial',
+    factory: midnightEmberTheme,
+    preview: {
+      primary: '#ea580c',
+      secondary: '#475569',
+      bg: '#f8fafc',
+      bgDark: '#0c0a09',
     },
   },
 };

--- a/src/shared/context/themes/lavenderHaze.js
+++ b/src/shared/context/themes/lavenderHaze.js
@@ -1,0 +1,354 @@
+// Lavender Haze theme — soft, modern, dreamy with pastel glows in dark mode.
+
+const bodyFont = '"Nunito", system-ui, sans-serif';
+const headingFont = '"Poppins", system-ui, sans-serif';
+
+export const lavenderHazeTheme = (isDark) => ({
+  palette: {
+    mode: isDark ? 'dark' : 'light',
+    primary: {
+      main: isDark ? '#a78bfa' : '#7c3aed',
+      light: isDark ? '#c4b5fd' : '#a78bfa',
+      dark: isDark ? '#7c3aed' : '#6d28d9',
+      contrastText: '#ffffff',
+    },
+    secondary: {
+      main: isDark ? '#fb7185' : '#e11d48',
+      light: isDark ? '#fda4af' : '#fb7185',
+      dark: isDark ? '#e11d48' : '#be123c',
+      contrastText: '#ffffff',
+    },
+    success: {
+      main: isDark ? '#4ade80' : '#16a34a',
+      light: isDark ? '#86efac' : '#4ade80',
+      dark: isDark ? '#16a34a' : '#15803d',
+    },
+    warning: {
+      main: isDark ? '#fbbf24' : '#d97706',
+      light: isDark ? '#fde68a' : '#fbbf24',
+      dark: isDark ? '#d97706' : '#b45309',
+    },
+    error: {
+      main: isDark ? '#f87171' : '#dc2626',
+      light: isDark ? '#fca5a5' : '#f87171',
+      dark: isDark ? '#dc2626' : '#b91c1c',
+    },
+    info: {
+      main: isDark ? '#818cf8' : '#4f46e5',
+      light: isDark ? '#a5b4fc' : '#818cf8',
+      dark: isDark ? '#4f46e5' : '#4338ca',
+    },
+    background: {
+      default: isDark ? '#0f0720' : '#faf5ff',
+      paper: isDark ? '#1a1030' : '#ffffff',
+      accent: isDark ? '#2a1a48' : '#f3e8ff',
+    },
+    text: {
+      primary: isDark ? '#f5f3ff' : '#1e1030',
+      secondary: isDark ? '#a199b8' : '#6b5f80',
+    },
+    divider: isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)',
+  },
+
+  shape: {
+    borderRadius: 20,
+  },
+
+  typography: {
+    fontFamily: bodyFont,
+    h1: {
+      fontFamily: headingFont,
+      fontWeight: 800,
+      letterSpacing: '-0.025em',
+    },
+    h2: {
+      fontFamily: headingFont,
+      fontWeight: 700,
+      letterSpacing: '-0.025em',
+    },
+    h3: {
+      fontFamily: headingFont,
+      fontWeight: 700,
+      letterSpacing: '-0.01em',
+    },
+    h4: {
+      fontFamily: headingFont,
+      fontWeight: 700,
+    },
+    h5: {
+      fontFamily: bodyFont,
+      fontWeight: 700,
+    },
+    h6: {
+      fontFamily: bodyFont,
+      fontWeight: 700,
+    },
+    subtitle1: { fontWeight: 600 },
+    subtitle2: { fontWeight: 600 },
+    button: {
+      textTransform: 'none',
+      fontWeight: 600,
+      letterSpacing: 0.2,
+    },
+    body2: {
+      color: isDark ? '#a199b8' : '#6b5f80',
+    },
+  },
+
+  components: {
+    MuiButton: {
+      styleOverrides: {
+        root: {
+          borderRadius: 20,
+          transition: 'all 200ms ease',
+        },
+        contained: {
+          boxShadow: 'none',
+          '&:hover': {
+            boxShadow: isDark
+              ? '0 4px 20px rgba(167,139,250,0.3)'
+              : '0 4px 14px rgba(124,58,237,0.2)',
+          },
+        },
+        outlined: {
+          borderColor: isDark ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.12)',
+          '&:hover': {
+            borderColor: isDark ? '#a78bfa' : '#7c3aed',
+            boxShadow: isDark ? '0 0 12px rgba(167,139,250,0.15)' : 'none',
+          },
+        },
+      },
+    },
+
+    MuiPaper: {
+      styleOverrides: {
+        root: {
+          borderRadius: 20,
+          backgroundImage: 'none',
+          transition: 'box-shadow 200ms ease, border-color 200ms ease',
+          ...(isDark && {
+            backgroundColor: '#1a1030',
+            border: '1px solid rgba(255,255,255,0.06)',
+          }),
+        },
+      },
+    },
+
+    MuiCard: {
+      defaultProps: {
+        elevation: 0,
+      },
+      styleOverrides: {
+        root: {
+          border: `1px solid ${isDark ? 'rgba(255,255,255,0.06)' : '#e9e0f0'}`,
+          boxShadow: isDark
+            ? '0 2px 12px rgba(0,0,0,0.3)'
+            : '0 2px 10px rgba(124,58,237,0.05), 0 1px 3px rgba(0,0,0,0.04)',
+          transition: 'all 200ms ease',
+          '&:hover': {
+            borderColor: isDark ? 'rgba(167,139,250,0.15)' : '#d6c8e8',
+            boxShadow: isDark
+              ? '0 6px 24px rgba(0,0,0,0.4), 0 0 16px rgba(167,139,250,0.08)'
+              : '0 6px 20px rgba(124,58,237,0.08)',
+          },
+        },
+      },
+    },
+
+    MuiCardContent: {
+      styleOverrides: {
+        root: ({ theme: t }) => ({
+          padding: '16px 16px 12px',
+          [t.breakpoints.up('sm')]: {
+            padding: '20px 20px 16px',
+          },
+          '&:last-child': {
+            paddingBottom: 16,
+            [t.breakpoints.up('sm')]: {
+              paddingBottom: 20,
+            },
+          },
+        }),
+      },
+    },
+
+    MuiAppBar: {
+      styleOverrides: {
+        root: {
+          backgroundColor: isDark
+            ? 'rgba(15, 7, 32, 0.95)'
+            : 'rgba(250, 245, 255, 0.95)',
+          backdropFilter: 'blur(12px)',
+          boxShadow: 'none',
+          borderBottom: isDark
+            ? '1px solid rgba(255,255,255,0.06)'
+            : '1px solid rgba(0,0,0,0.06)',
+        },
+      },
+    },
+
+    MuiTab: {
+      styleOverrides: {
+        root: {
+          transition: 'all 200ms ease',
+          '&.Mui-selected': {
+            color: isDark ? '#a78bfa' : '#7c3aed',
+          },
+        },
+      },
+    },
+
+    MuiTabs: {
+      styleOverrides: {
+        indicator: {
+          backgroundColor: isDark ? '#a78bfa' : '#7c3aed',
+          height: 3,
+          borderRadius: '3px 3px 0 0',
+        },
+      },
+    },
+
+    MuiTextField: {
+      styleOverrides: {
+        root: {
+          '& .MuiOutlinedInput-root': {
+            '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+              borderColor: isDark ? '#a78bfa' : '#7c3aed',
+            },
+          },
+        },
+      },
+    },
+
+    MuiAccordion: {
+      styleOverrides: {
+        root: {
+          backgroundColor: isDark ? '#1a1030' : '#ffffff',
+          '&::before': {
+            display: 'none',
+          },
+        },
+      },
+    },
+
+    MuiDialog: {
+      styleOverrides: {
+        paper: {
+          backgroundColor: isDark ? '#1a1030' : '#ffffff',
+          border: isDark ? '1px solid rgba(255,255,255,0.06)' : 'none',
+          boxShadow: isDark
+            ? '0 24px 48px rgba(0,0,0,0.5), 0 0 20px rgba(167,139,250,0.06)'
+            : '0 24px 48px rgba(0,0,0,0.12)',
+        },
+      },
+    },
+
+    MuiBackdrop: {
+      styleOverrides: {
+        root: {
+          backgroundColor: isDark
+            ? 'rgba(0, 0, 0, 0.5)'
+            : 'rgba(0, 0, 0, 0.3)',
+          backdropFilter: 'blur(4px)',
+          WebkitBackdropFilter: 'blur(4px)',
+        },
+      },
+    },
+
+    MuiBottomNavigation: {
+      styleOverrides: {
+        root: {
+          backgroundColor: isDark
+            ? 'rgba(15, 7, 32, 0.95)'
+            : 'rgba(250, 245, 255, 0.98)',
+          backdropFilter: 'blur(12px)',
+        },
+      },
+    },
+
+    MuiBottomNavigationAction: {
+      styleOverrides: {
+        root: {
+          color: isDark ? '#a199b8' : '#6b5f80',
+          '&.Mui-selected': {
+            color: isDark ? '#a78bfa' : '#7c3aed',
+          },
+        },
+      },
+    },
+
+    MuiLinearProgress: {
+      styleOverrides: {
+        root: {
+          borderRadius: 10,
+          backgroundColor: isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)',
+        },
+        bar: {
+          borderRadius: 10,
+        },
+      },
+    },
+
+    MuiFab: {
+      styleOverrides: {
+        root: {
+          boxShadow: isDark
+            ? '0 4px 14px rgba(167,139,250,0.3)'
+            : '0 4px 14px rgba(124,58,237,0.25)',
+        },
+      },
+    },
+
+    MuiSwitch: {
+      styleOverrides: {
+        switchBase: {
+          '&.Mui-checked': {
+            color: isDark ? '#a78bfa' : '#7c3aed',
+            '& + .MuiSwitch-track': {
+              backgroundColor: isDark ? '#a78bfa' : '#7c3aed',
+            },
+          },
+        },
+      },
+    },
+
+    MuiAlert: {
+      styleOverrides: {
+        root: {
+          borderRadius: 20,
+        },
+      },
+    },
+
+    MuiChip: {
+      styleOverrides: {
+        outlined: {
+          borderColor: isDark ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.12)',
+        },
+      },
+    },
+  },
+
+  // Custom namespace for app-specific tokens
+  custom: {
+    glowStyle: 'soft',
+    macroColors: {
+      calories: '#f59e0b',
+      protein: '#6366f1',
+      carbs: '#ec4899',
+      fat: '#8b5cf6',
+    },
+    cssClass: 'theme-lavender-haze',
+    toast: {
+      className: '',
+      success: {
+        primary: isDark ? '#4ade80' : '#16a34a',
+        secondary: isDark ? '#1a1030' : '#ffffff',
+      },
+      error: {
+        primary: isDark ? '#f87171' : '#dc2626',
+        secondary: isDark ? '#1a1030' : '#ffffff',
+      },
+    },
+  },
+});

--- a/src/shared/context/themes/midnightEmber.js
+++ b/src/shared/context/themes/midnightEmber.js
@@ -1,0 +1,355 @@
+// Midnight Ember theme — bold, industrial, sharp with hard box-shadows and angular feel.
+
+const bodyFont = '"IBM Plex Sans", system-ui, sans-serif';
+const headingFont = '"Space Grotesk", system-ui, sans-serif';
+
+export const midnightEmberTheme = (isDark) => ({
+  palette: {
+    mode: isDark ? 'dark' : 'light',
+    primary: {
+      main: isDark ? '#fb923c' : '#ea580c',
+      light: isDark ? '#fdba74' : '#fb923c',
+      dark: isDark ? '#ea580c' : '#c2410c',
+      contrastText: '#ffffff',
+    },
+    secondary: {
+      main: isDark ? '#94a3b8' : '#475569',
+      light: isDark ? '#cbd5e1' : '#94a3b8',
+      dark: isDark ? '#475569' : '#334155',
+      contrastText: '#ffffff',
+    },
+    success: {
+      main: isDark ? '#4ade80' : '#16a34a',
+      light: isDark ? '#86efac' : '#4ade80',
+      dark: isDark ? '#16a34a' : '#15803d',
+    },
+    warning: {
+      main: isDark ? '#fbbf24' : '#d97706',
+      light: isDark ? '#fde68a' : '#fbbf24',
+      dark: isDark ? '#d97706' : '#b45309',
+    },
+    error: {
+      main: isDark ? '#f87171' : '#dc2626',
+      light: isDark ? '#fca5a5' : '#f87171',
+      dark: isDark ? '#dc2626' : '#b91c1c',
+    },
+    info: {
+      main: isDark ? '#38bdf8' : '#0284c7',
+      light: isDark ? '#7dd3fc' : '#38bdf8',
+      dark: isDark ? '#0284c7' : '#0369a1',
+    },
+    background: {
+      default: isDark ? '#0c0a09' : '#f8fafc',
+      paper: isDark ? '#1c1917' : '#ffffff',
+      accent: isDark ? '#292524' : '#f1f5f9',
+    },
+    text: {
+      primary: isDark ? '#fafaf9' : '#0c0a09',
+      secondary: isDark ? '#a8a29e' : '#57534e',
+    },
+    divider: isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.1)',
+  },
+
+  shape: {
+    borderRadius: 4,
+  },
+
+  typography: {
+    fontFamily: bodyFont,
+    h1: {
+      fontFamily: headingFont,
+      fontWeight: 800,
+      letterSpacing: '-0.03em',
+    },
+    h2: {
+      fontFamily: headingFont,
+      fontWeight: 700,
+      letterSpacing: '-0.02em',
+    },
+    h3: {
+      fontFamily: headingFont,
+      fontWeight: 700,
+      letterSpacing: '-0.01em',
+    },
+    h4: {
+      fontFamily: headingFont,
+      fontWeight: 700,
+    },
+    h5: {
+      fontFamily: bodyFont,
+      fontWeight: 700,
+    },
+    h6: {
+      fontFamily: bodyFont,
+      fontWeight: 700,
+    },
+    subtitle1: { fontWeight: 600 },
+    subtitle2: { fontWeight: 600 },
+    button: {
+      textTransform: 'none',
+      fontWeight: 600,
+      letterSpacing: 0.3,
+    },
+    body2: {
+      color: isDark ? '#a8a29e' : '#57534e',
+    },
+  },
+
+  components: {
+    MuiButton: {
+      styleOverrides: {
+        root: {
+          borderRadius: 4,
+          transition: 'all 150ms ease',
+        },
+        contained: {
+          boxShadow: isDark
+            ? '2px 2px 0 rgba(0,0,0,0.4)'
+            : '2px 2px 0 rgba(0,0,0,0.12)',
+          '&:hover': {
+            boxShadow: isDark
+              ? '3px 3px 0 rgba(0,0,0,0.5)'
+              : '3px 3px 0 rgba(0,0,0,0.15)',
+          },
+        },
+        outlined: {
+          borderColor: isDark ? 'rgba(255,255,255,0.15)' : 'rgba(0,0,0,0.15)',
+          '&:hover': {
+            borderColor: isDark ? '#fb923c' : '#ea580c',
+          },
+        },
+      },
+    },
+
+    MuiPaper: {
+      styleOverrides: {
+        root: {
+          borderRadius: 6,
+          backgroundImage: 'none',
+          transition: 'box-shadow 150ms ease, border-color 150ms ease',
+          ...(isDark && {
+            backgroundColor: '#1c1917',
+            border: '1px solid rgba(255,255,255,0.06)',
+          }),
+        },
+      },
+    },
+
+    MuiCard: {
+      defaultProps: {
+        elevation: 0,
+      },
+      styleOverrides: {
+        root: {
+          border: `1px solid ${isDark ? 'rgba(255,255,255,0.08)' : '#e7e5e4'}`,
+          boxShadow: isDark
+            ? '3px 3px 0 rgba(0,0,0,0.3)'
+            : '3px 3px 0 rgba(0,0,0,0.08)',
+          transition: 'all 150ms ease',
+          '&:hover': {
+            borderColor: isDark ? 'rgba(255,255,255,0.12)' : '#d6d3d1',
+            boxShadow: isDark
+              ? '4px 4px 0 rgba(0,0,0,0.4)'
+              : '4px 4px 0 rgba(0,0,0,0.12)',
+          },
+        },
+      },
+    },
+
+    MuiCardContent: {
+      styleOverrides: {
+        root: ({ theme: t }) => ({
+          padding: '16px 16px 12px',
+          [t.breakpoints.up('sm')]: {
+            padding: '20px 20px 16px',
+          },
+          '&:last-child': {
+            paddingBottom: 16,
+            [t.breakpoints.up('sm')]: {
+              paddingBottom: 20,
+            },
+          },
+        }),
+      },
+    },
+
+    MuiAppBar: {
+      styleOverrides: {
+        root: {
+          backgroundColor: isDark
+            ? 'rgba(12, 10, 9, 0.95)'
+            : 'rgba(248, 250, 252, 0.95)',
+          backdropFilter: 'blur(12px)',
+          boxShadow: 'none',
+          borderBottom: isDark
+            ? '1px solid rgba(255,255,255,0.08)'
+            : '1px solid rgba(0,0,0,0.08)',
+        },
+      },
+    },
+
+    MuiTab: {
+      styleOverrides: {
+        root: {
+          transition: 'all 150ms ease',
+          '&.Mui-selected': {
+            color: isDark ? '#fb923c' : '#ea580c',
+          },
+        },
+      },
+    },
+
+    MuiTabs: {
+      styleOverrides: {
+        indicator: {
+          backgroundColor: isDark ? '#fb923c' : '#ea580c',
+          height: 3,
+          borderRadius: '3px 3px 0 0',
+        },
+      },
+    },
+
+    MuiTextField: {
+      styleOverrides: {
+        root: {
+          '& .MuiOutlinedInput-root': {
+            '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+              borderColor: isDark ? '#fb923c' : '#ea580c',
+            },
+          },
+        },
+      },
+    },
+
+    MuiAccordion: {
+      styleOverrides: {
+        root: {
+          backgroundColor: isDark ? '#1c1917' : '#ffffff',
+          '&::before': {
+            display: 'none',
+          },
+        },
+      },
+    },
+
+    MuiDialog: {
+      styleOverrides: {
+        paper: {
+          backgroundColor: isDark ? '#1c1917' : '#ffffff',
+          border: isDark ? '1px solid rgba(255,255,255,0.08)' : 'none',
+          boxShadow: isDark
+            ? '6px 6px 0 rgba(0,0,0,0.5)'
+            : '6px 6px 0 rgba(0,0,0,0.1)',
+        },
+      },
+    },
+
+    MuiBackdrop: {
+      styleOverrides: {
+        root: {
+          backgroundColor: isDark
+            ? 'rgba(0, 0, 0, 0.6)'
+            : 'rgba(0, 0, 0, 0.35)',
+          backdropFilter: 'blur(4px)',
+          WebkitBackdropFilter: 'blur(4px)',
+        },
+      },
+    },
+
+    MuiBottomNavigation: {
+      styleOverrides: {
+        root: {
+          backgroundColor: isDark
+            ? 'rgba(12, 10, 9, 0.95)'
+            : 'rgba(248, 250, 252, 0.98)',
+          backdropFilter: 'blur(12px)',
+        },
+      },
+    },
+
+    MuiBottomNavigationAction: {
+      styleOverrides: {
+        root: {
+          color: isDark ? '#a8a29e' : '#57534e',
+          '&.Mui-selected': {
+            color: isDark ? '#fb923c' : '#ea580c',
+          },
+        },
+      },
+    },
+
+    MuiLinearProgress: {
+      styleOverrides: {
+        root: {
+          borderRadius: 2,
+          backgroundColor: isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)',
+        },
+        bar: {
+          borderRadius: 2,
+        },
+      },
+    },
+
+    MuiFab: {
+      styleOverrides: {
+        root: {
+          boxShadow: isDark
+            ? '3px 3px 0 rgba(0,0,0,0.4)'
+            : '3px 3px 0 rgba(0,0,0,0.15)',
+        },
+      },
+    },
+
+    MuiSwitch: {
+      styleOverrides: {
+        switchBase: {
+          '&.Mui-checked': {
+            color: isDark ? '#fb923c' : '#ea580c',
+            '& + .MuiSwitch-track': {
+              backgroundColor: isDark ? '#fb923c' : '#ea580c',
+            },
+          },
+        },
+      },
+    },
+
+    MuiAlert: {
+      styleOverrides: {
+        root: {
+          borderRadius: 4,
+        },
+      },
+    },
+
+    MuiChip: {
+      styleOverrides: {
+        outlined: {
+          borderColor: isDark ? 'rgba(255,255,255,0.15)' : 'rgba(0,0,0,0.12)',
+        },
+      },
+    },
+  },
+
+  // Custom namespace for app-specific tokens
+  custom: {
+    glowStyle: 'none',
+    macroColors: {
+      calories: '#f59e0b',
+      protein: '#0ea5e9',
+      carbs: '#ef4444',
+      fat: '#a855f7',
+    },
+    cssClass: 'theme-midnight-ember',
+    toast: {
+      className: '',
+      success: {
+        primary: isDark ? '#4ade80' : '#16a34a',
+        secondary: isDark ? '#1c1917' : '#ffffff',
+      },
+      error: {
+        primary: isDark ? '#f87171' : '#dc2626',
+        secondary: isDark ? '#1c1917' : '#ffffff',
+      },
+    },
+  },
+});

--- a/src/shared/context/themes/oceanBreeze.js
+++ b/src/shared/context/themes/oceanBreeze.js
@@ -1,0 +1,353 @@
+// Ocean Breeze theme — calm, coastal, refreshing with soft drop shadows.
+
+const bodyFont = '"Inter", system-ui, sans-serif';
+const headingFont = '"DM Sans", system-ui, sans-serif';
+
+export const oceanBreezeTheme = (isDark) => ({
+  palette: {
+    mode: isDark ? 'dark' : 'light',
+    primary: {
+      main: isDark ? '#2dd4bf' : '#0d9488',
+      light: isDark ? '#5eead4' : '#2dd4bf',
+      dark: isDark ? '#0d9488' : '#0f766e',
+      contrastText: '#ffffff',
+    },
+    secondary: {
+      main: isDark ? '#fb923c' : '#f97316',
+      light: isDark ? '#fdba74' : '#fb923c',
+      dark: isDark ? '#f97316' : '#ea580c',
+      contrastText: '#ffffff',
+    },
+    success: {
+      main: isDark ? '#4ade80' : '#16a34a',
+      light: isDark ? '#86efac' : '#4ade80',
+      dark: isDark ? '#16a34a' : '#15803d',
+    },
+    warning: {
+      main: isDark ? '#fbbf24' : '#d97706',
+      light: isDark ? '#fde68a' : '#fbbf24',
+      dark: isDark ? '#d97706' : '#b45309',
+    },
+    error: {
+      main: isDark ? '#f87171' : '#dc2626',
+      light: isDark ? '#fca5a5' : '#f87171',
+      dark: isDark ? '#dc2626' : '#b91c1c',
+    },
+    info: {
+      main: isDark ? '#38bdf8' : '#0284c7',
+      light: isDark ? '#7dd3fc' : '#38bdf8',
+      dark: isDark ? '#0284c7' : '#0369a1',
+    },
+    background: {
+      default: isDark ? '#0f172a' : '#f0fdfa',
+      paper: isDark ? '#1e293b' : '#ffffff',
+      accent: isDark ? '#334155' : '#ccfbf1',
+    },
+    text: {
+      primary: isDark ? '#f0fdfa' : '#0f172a',
+      secondary: isDark ? '#94a3b8' : '#64748b',
+    },
+    divider: isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)',
+  },
+
+  shape: {
+    borderRadius: 16,
+  },
+
+  typography: {
+    fontFamily: bodyFont,
+    h1: {
+      fontFamily: headingFont,
+      fontWeight: 800,
+      letterSpacing: '-0.025em',
+    },
+    h2: {
+      fontFamily: headingFont,
+      fontWeight: 700,
+      letterSpacing: '-0.025em',
+    },
+    h3: {
+      fontFamily: headingFont,
+      fontWeight: 700,
+      letterSpacing: '-0.01em',
+    },
+    h4: {
+      fontFamily: headingFont,
+      fontWeight: 700,
+    },
+    h5: {
+      fontFamily: bodyFont,
+      fontWeight: 700,
+    },
+    h6: {
+      fontFamily: bodyFont,
+      fontWeight: 700,
+    },
+    subtitle1: { fontWeight: 600 },
+    subtitle2: { fontWeight: 600 },
+    button: {
+      textTransform: 'none',
+      fontWeight: 600,
+      letterSpacing: 0.2,
+    },
+    body2: {
+      color: isDark ? '#94a3b8' : '#64748b',
+    },
+  },
+
+  components: {
+    MuiButton: {
+      styleOverrides: {
+        root: {
+          borderRadius: 16,
+          transition: 'all 200ms ease',
+        },
+        contained: {
+          boxShadow: 'none',
+          '&:hover': {
+            boxShadow: isDark
+              ? '0 4px 14px rgba(45,212,191,0.2)'
+              : '0 4px 14px rgba(13,148,136,0.2)',
+          },
+        },
+        outlined: {
+          borderColor: isDark ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.12)',
+          '&:hover': {
+            borderColor: isDark ? '#2dd4bf' : '#0d9488',
+          },
+        },
+      },
+    },
+
+    MuiPaper: {
+      styleOverrides: {
+        root: {
+          borderRadius: 16,
+          backgroundImage: 'none',
+          transition: 'box-shadow 200ms ease, border-color 200ms ease',
+          ...(isDark && {
+            backgroundColor: '#1e293b',
+            border: '1px solid rgba(255,255,255,0.06)',
+          }),
+        },
+      },
+    },
+
+    MuiCard: {
+      defaultProps: {
+        elevation: 0,
+      },
+      styleOverrides: {
+        root: {
+          border: `1px solid ${isDark ? 'rgba(255,255,255,0.06)' : '#e2e8f0'}`,
+          boxShadow: isDark
+            ? '0 2px 8px rgba(0,0,0,0.3)'
+            : '0 2px 8px rgba(0,0,0,0.05), 0 1px 3px rgba(0,0,0,0.03)',
+          transition: 'all 200ms ease',
+          '&:hover': {
+            borderColor: isDark ? 'rgba(255,255,255,0.1)' : '#cbd5e1',
+            boxShadow: isDark
+              ? '0 6px 20px rgba(0,0,0,0.4)'
+              : '0 6px 20px rgba(0,0,0,0.08)',
+          },
+        },
+      },
+    },
+
+    MuiCardContent: {
+      styleOverrides: {
+        root: ({ theme: t }) => ({
+          padding: '16px 16px 12px',
+          [t.breakpoints.up('sm')]: {
+            padding: '20px 20px 16px',
+          },
+          '&:last-child': {
+            paddingBottom: 16,
+            [t.breakpoints.up('sm')]: {
+              paddingBottom: 20,
+            },
+          },
+        }),
+      },
+    },
+
+    MuiAppBar: {
+      styleOverrides: {
+        root: {
+          backgroundColor: isDark
+            ? 'rgba(15, 23, 42, 0.95)'
+            : 'rgba(240, 253, 250, 0.95)',
+          backdropFilter: 'blur(12px)',
+          boxShadow: 'none',
+          borderBottom: isDark
+            ? '1px solid rgba(255,255,255,0.06)'
+            : '1px solid rgba(0,0,0,0.06)',
+        },
+      },
+    },
+
+    MuiTab: {
+      styleOverrides: {
+        root: {
+          transition: 'all 200ms ease',
+          '&.Mui-selected': {
+            color: isDark ? '#2dd4bf' : '#0d9488',
+          },
+        },
+      },
+    },
+
+    MuiTabs: {
+      styleOverrides: {
+        indicator: {
+          backgroundColor: isDark ? '#2dd4bf' : '#0d9488',
+          height: 3,
+          borderRadius: '3px 3px 0 0',
+        },
+      },
+    },
+
+    MuiTextField: {
+      styleOverrides: {
+        root: {
+          '& .MuiOutlinedInput-root': {
+            '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+              borderColor: isDark ? '#2dd4bf' : '#0d9488',
+            },
+          },
+        },
+      },
+    },
+
+    MuiAccordion: {
+      styleOverrides: {
+        root: {
+          backgroundColor: isDark ? '#1e293b' : '#ffffff',
+          '&::before': {
+            display: 'none',
+          },
+        },
+      },
+    },
+
+    MuiDialog: {
+      styleOverrides: {
+        paper: {
+          backgroundColor: isDark ? '#1e293b' : '#ffffff',
+          border: isDark ? '1px solid rgba(255,255,255,0.06)' : 'none',
+          boxShadow: isDark
+            ? '0 24px 48px rgba(0,0,0,0.5)'
+            : '0 24px 48px rgba(0,0,0,0.12)',
+        },
+      },
+    },
+
+    MuiBackdrop: {
+      styleOverrides: {
+        root: {
+          backgroundColor: isDark
+            ? 'rgba(0, 0, 0, 0.5)'
+            : 'rgba(0, 0, 0, 0.3)',
+          backdropFilter: 'blur(4px)',
+          WebkitBackdropFilter: 'blur(4px)',
+        },
+      },
+    },
+
+    MuiBottomNavigation: {
+      styleOverrides: {
+        root: {
+          backgroundColor: isDark
+            ? 'rgba(15, 23, 42, 0.95)'
+            : 'rgba(240, 253, 250, 0.98)',
+          backdropFilter: 'blur(12px)',
+        },
+      },
+    },
+
+    MuiBottomNavigationAction: {
+      styleOverrides: {
+        root: {
+          color: isDark ? '#94a3b8' : '#64748b',
+          '&.Mui-selected': {
+            color: isDark ? '#2dd4bf' : '#0d9488',
+          },
+        },
+      },
+    },
+
+    MuiLinearProgress: {
+      styleOverrides: {
+        root: {
+          borderRadius: 8,
+          backgroundColor: isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)',
+        },
+        bar: {
+          borderRadius: 8,
+        },
+      },
+    },
+
+    MuiFab: {
+      styleOverrides: {
+        root: {
+          boxShadow: isDark
+            ? '0 4px 14px rgba(45,212,191,0.3)'
+            : '0 4px 14px rgba(13,148,136,0.25)',
+        },
+      },
+    },
+
+    MuiSwitch: {
+      styleOverrides: {
+        switchBase: {
+          '&.Mui-checked': {
+            color: isDark ? '#2dd4bf' : '#0d9488',
+            '& + .MuiSwitch-track': {
+              backgroundColor: isDark ? '#2dd4bf' : '#0d9488',
+            },
+          },
+        },
+      },
+    },
+
+    MuiAlert: {
+      styleOverrides: {
+        root: {
+          borderRadius: 16,
+        },
+      },
+    },
+
+    MuiChip: {
+      styleOverrides: {
+        outlined: {
+          borderColor: isDark ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.12)',
+        },
+      },
+    },
+  },
+
+  // Custom namespace for app-specific tokens
+  custom: {
+    glowStyle: 'none',
+    macroColors: {
+      calories: '#f59e0b',
+      protein: '#06b6d4',
+      carbs: '#f43f5e',
+      fat: '#8b5cf6',
+    },
+    cssClass: 'theme-ocean-breeze',
+    toast: {
+      className: '',
+      success: {
+        primary: isDark ? '#4ade80' : '#16a34a',
+        secondary: isDark ? '#1e293b' : '#ffffff',
+      },
+      error: {
+        primary: isDark ? '#f87171' : '#dc2626',
+        secondary: isDark ? '#1e293b' : '#ffffff',
+      },
+    },
+  },
+});

--- a/src/shared/context/themes/tokyoNights.js
+++ b/src/shared/context/themes/tokyoNights.js
@@ -1,0 +1,391 @@
+// Tokyo Nights theme — cyberpunk neon aesthetic with Orbitron + Urbanist typography.
+// Extracted from the original ThemeContext.jsx hardcoded theme.
+
+const neonGlow = {
+  pink: '0 0 20px rgba(255,45,120,0.3), 0 0 60px rgba(255,45,120,0.1)',
+  cyan: '0 0 20px rgba(0,229,255,0.3), 0 0 60px rgba(0,229,255,0.1)',
+  amber: '0 0 20px rgba(255,176,32,0.3)',
+  green: '0 0 20px rgba(57,255,127,0.3)',
+  purple: '0 0 20px rgba(168,85,247,0.3)',
+};
+
+export const tokyoNightsTheme = (isDark) => ({
+  palette: {
+    mode: isDark ? 'dark' : 'light',
+    primary: {
+      main: isDark ? '#ff2d78' : '#d6245e',
+      light: isDark ? '#ff6da0' : '#e8507a',
+      dark: isDark ? '#c4205d' : '#a81c4a',
+      contrastText: '#ffffff',
+    },
+    secondary: {
+      main: isDark ? '#00e5ff' : '#00b8d4',
+      light: isDark ? '#6effff' : '#62efff',
+      dark: isDark ? '#00b2c8' : '#008ba3',
+      contrastText: isDark ? '#0a0a12' : '#ffffff',
+    },
+    success: {
+      main: isDark ? '#39ff7f' : '#2ecc71',
+      light: isDark ? '#80ffb0' : '#a3e4bc',
+      dark: isDark ? '#1fb85c' : '#1fa04e',
+    },
+    warning: {
+      main: isDark ? '#ffb020' : '#e09b18',
+      light: isDark ? '#ffd070' : '#f5d890',
+      dark: isDark ? '#c88a18' : '#b07812',
+    },
+    error: {
+      main: isDark ? '#ff4757' : '#e03e4e',
+      light: isDark ? '#ff8a94' : '#f0888f',
+      dark: isDark ? '#cc3644' : '#b0303e',
+    },
+    info: {
+      main: isDark ? '#a855f7' : '#8b3fd4',
+      light: isDark ? '#c88aff' : '#b48ae0',
+      dark: isDark ? '#7c3aed' : '#6d2eb0',
+    },
+    background: {
+      default: isDark ? '#0a0a12' : '#f4f2ee',
+      paper: isDark ? '#12121e' : '#ffffff',
+      accent: isDark ? '#1a1a2e' : '#eae7e0',
+    },
+    text: {
+      primary: isDark ? '#e8e6f0' : '#1a1a2e',
+      secondary: isDark ? '#7a78a0' : '#6b6980',
+    },
+    divider: isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.08)',
+  },
+
+  shape: {
+    borderRadius: 12,
+  },
+
+  typography: {
+    fontFamily: '"Urbanist", system-ui, -apple-system, sans-serif',
+    h1: {
+      fontFamily: '"Orbitron", sans-serif',
+      fontWeight: 900,
+      letterSpacing: 1,
+      textTransform: 'uppercase',
+    },
+    h2: {
+      fontFamily: '"Orbitron", sans-serif',
+      fontWeight: 700,
+      letterSpacing: 0.5,
+      textTransform: 'uppercase',
+    },
+    h3: {
+      fontFamily: '"Orbitron", sans-serif',
+      fontWeight: 700,
+      letterSpacing: 0.5,
+      textTransform: 'uppercase',
+    },
+    h4: {
+      fontFamily: '"Orbitron", sans-serif',
+      fontWeight: 700,
+      letterSpacing: 0.25,
+    },
+    h5: {
+      fontFamily: '"Urbanist", sans-serif',
+      fontWeight: 700,
+    },
+    h6: {
+      fontFamily: '"Urbanist", sans-serif',
+      fontWeight: 700,
+    },
+    subtitle1: { fontWeight: 600 },
+    subtitle2: { fontWeight: 600 },
+    button: {
+      textTransform: 'none',
+      fontWeight: 600,
+      letterSpacing: 0.25,
+    },
+    body2: {
+      color: isDark ? '#9a98b8' : '#6b6980',
+    },
+  },
+
+  components: {
+    MuiButton: {
+      styleOverrides: {
+        root: {
+          borderRadius: 8,
+          transition: 'all 250ms ease-out',
+        },
+        contained: {
+          boxShadow: isDark ? neonGlow.pink : 'none',
+          '&:hover': {
+            boxShadow: isDark
+              ? '0 0 30px rgba(255,45,120,0.4), 0 0 80px rgba(255,45,120,0.15)'
+              : '0 4px 16px rgba(214,36,94,0.3)',
+          },
+        },
+        outlined: {
+          borderColor: isDark ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.12)',
+          '&:hover': {
+            borderColor: isDark ? '#ff2d78' : '#d6245e',
+            boxShadow: isDark ? '0 0 12px rgba(255,45,120,0.2)' : 'none',
+          },
+        },
+      },
+    },
+
+    MuiBackdrop: {
+      styleOverrides: {
+        root: {
+          backgroundColor: isDark
+            ? 'rgba(2, 6, 23, 0.6)'
+            : 'rgba(15, 23, 42, 0.35)',
+          backdropFilter: 'blur(6px)',
+          WebkitBackdropFilter: 'blur(6px)',
+        },
+      },
+    },
+
+    MuiSkeleton: {
+      styleOverrides: {
+        root: {
+          backgroundImage:
+            'linear-gradient(90deg, #12121e 0%, #1a1a2e 50%, #12121e 100%)',
+          backgroundSize: '200% 100%',
+          animation: 'skeletonShimmer 1.6s ease-in-out infinite',
+        },
+      },
+    },
+
+    MuiPaper: {
+      styleOverrides: {
+        root: {
+          borderRadius: 16,
+          backgroundImage: 'none',
+          transition: 'box-shadow 250ms ease-out, border-color 250ms ease-out',
+          ...(isDark && {
+            backgroundColor: '#12121e',
+            border: '1px solid rgba(255,255,255,0.04)',
+            '&:hover': {
+              borderColor: 'rgba(255,45,120,0.15)',
+            },
+          }),
+        },
+      },
+    },
+
+    MuiCard: {
+      defaultProps: {
+        elevation: 0,
+      },
+      styleOverrides: {
+        root: {
+          border: `1px solid ${isDark ? 'rgba(255,255,255,0.06)' : '#e2e0d8'}`,
+          boxShadow: isDark
+            ? '0 4px 30px rgba(0,0,0,0.4)'
+            : '0 4px 20px rgba(0,0,0,0.06)',
+          transition: 'all 250ms ease-out',
+          '&:hover': {
+            borderColor: isDark ? 'rgba(255,45,120,0.2)' : 'rgba(214,36,94,0.15)',
+            boxShadow: isDark
+              ? '0 4px 30px rgba(0,0,0,0.4), 0 0 20px rgba(255,45,120,0.1)'
+              : '0 8px 30px rgba(0,0,0,0.08)',
+          },
+        },
+      },
+    },
+
+    MuiCardContent: {
+      styleOverrides: {
+        root: ({ theme: t }) => ({
+          padding: '16px 16px 12px',
+          [t.breakpoints.up('sm')]: {
+            padding: '20px 20px 16px',
+          },
+          '&:last-child': {
+            paddingBottom: 16,
+            [t.breakpoints.up('sm')]: {
+              paddingBottom: 20,
+            },
+          },
+        }),
+      },
+    },
+
+    MuiAppBar: {
+      styleOverrides: {
+        root: {
+          backgroundColor: isDark
+            ? 'rgba(10, 10, 18, 0.92)'
+            : 'rgba(244, 242, 238, 0.95)',
+          backdropFilter: 'blur(14px)',
+          boxShadow: 'none',
+          borderBottom: isDark
+            ? '1px solid rgba(255,255,255,0.04)'
+            : '1px solid rgba(0,0,0,0.06)',
+          '&::after': isDark ? {
+            content: '""',
+            position: 'absolute',
+            bottom: 0,
+            left: 0,
+            right: 0,
+            height: '1px',
+            background: 'linear-gradient(90deg, transparent, rgba(255,45,120,0.4), rgba(0,229,255,0.4), transparent)',
+          } : {},
+        },
+      },
+    },
+
+    MuiChip: {
+      styleOverrides: {
+        outlined: {
+          borderColor: isDark ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.12)',
+        },
+      },
+    },
+
+    MuiTab: {
+      styleOverrides: {
+        root: {
+          transition: 'all 250ms ease-out',
+          '&.Mui-selected': {
+            color: isDark ? '#ff2d78' : '#d6245e',
+          },
+        },
+      },
+    },
+
+    MuiTabs: {
+      styleOverrides: {
+        indicator: {
+          backgroundColor: isDark ? '#ff2d78' : '#d6245e',
+          height: 3,
+          borderRadius: '3px 3px 0 0',
+          boxShadow: isDark ? '0 0 10px rgba(255,45,120,0.5)' : 'none',
+        },
+      },
+    },
+
+    MuiTextField: {
+      styleOverrides: {
+        root: {
+          '& .MuiOutlinedInput-root': {
+            '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+              borderColor: isDark ? '#00e5ff' : '#00b8d4',
+              boxShadow: isDark ? '0 0 12px rgba(0,229,255,0.2)' : 'none',
+            },
+          },
+        },
+      },
+    },
+
+    MuiAccordion: {
+      styleOverrides: {
+        root: {
+          backgroundColor: isDark ? '#12121e' : '#ffffff',
+          '&::before': {
+            display: 'none',
+          },
+        },
+      },
+    },
+
+    MuiDialog: {
+      styleOverrides: {
+        paper: {
+          backgroundColor: isDark ? 'rgba(18, 18, 30, 0.8)' : '#ffffff',
+          backdropFilter: isDark ? 'blur(20px) saturate(140%)' : 'none',
+          WebkitBackdropFilter: isDark ? 'blur(20px) saturate(140%)' : 'none',
+          border: isDark ? '1px solid rgba(255,255,255,0.06)' : 'none',
+          boxShadow: isDark
+            ? '0 24px 80px rgba(0,0,0,0.6), 0 0 40px rgba(255,45,120,0.08)'
+            : '0 24px 80px rgba(0,0,0,0.15)',
+        },
+        backdrop: {
+          backgroundColor: isDark ? 'rgba(0,0,0,0.6)' : 'rgba(0,0,0,0.4)',
+          backdropFilter: 'blur(6px)',
+          WebkitBackdropFilter: 'blur(6px)',
+        },
+      },
+    },
+
+    MuiBottomNavigation: {
+      styleOverrides: {
+        root: {
+          backgroundColor: isDark
+            ? 'rgba(10, 10, 18, 0.95)'
+            : 'rgba(244, 242, 238, 0.98)',
+          backdropFilter: 'blur(14px)',
+        },
+      },
+    },
+
+    MuiBottomNavigationAction: {
+      styleOverrides: {
+        root: {
+          color: isDark ? '#7a78a0' : '#6b6980',
+          '&.Mui-selected': {
+            color: isDark ? '#ff2d78' : '#d6245e',
+          },
+        },
+      },
+    },
+
+    MuiLinearProgress: {
+      styleOverrides: {
+        root: {
+          borderRadius: 4,
+          backgroundColor: isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)',
+        },
+        bar: {
+          borderRadius: 4,
+        },
+      },
+    },
+
+    MuiFab: {
+      styleOverrides: {
+        root: {
+          boxShadow: isDark ? neonGlow.pink : '0 4px 16px rgba(214,36,94,0.3)',
+        },
+      },
+    },
+
+    MuiSwitch: {
+      styleOverrides: {
+        switchBase: {
+          '&.Mui-checked': {
+            color: isDark ? '#ff2d78' : '#d6245e',
+            '& + .MuiSwitch-track': {
+              backgroundColor: isDark ? '#ff2d78' : '#d6245e',
+            },
+          },
+        },
+      },
+    },
+
+    MuiAlert: {
+      styleOverrides: {
+        root: {
+          borderRadius: 12,
+        },
+      },
+    },
+  },
+
+  // Custom namespace for app-specific tokens
+  custom: {
+    glowStyle: 'neon',
+    neonGlow: neonGlow,
+    macroColors: {
+      calories: '#ffb020',
+      protein: '#00e5ff',
+      carbs: '#ff2d78',
+      fat: '#a855f7',
+    },
+    cssClass: 'theme-tokyo-nights',
+    toast: {
+      className: 'toast-neon',
+      success: { primary: '#39ff7f', secondary: '#12121e' },
+      error: { primary: '#ff4757', secondary: '#12121e' },
+    },
+  },
+});
+
+export { neonGlow };

--- a/src/shared/services/userPreferences.js
+++ b/src/shared/services/userPreferences.js
@@ -6,7 +6,7 @@ const preferencesRef = (uid) => doc(db, 'userPreferences', uid);
 
 const DEFAULT_PREFERENCES = {
   showRecentIngredients: true,
-  // Add more preferences here in the future
+  themePrefs: null, // { themeName, isDark, customConfig }
 };
 
 /**

--- a/src/test/testUtils.jsx
+++ b/src/test/testUtils.jsx
@@ -50,14 +50,20 @@ export const mockMealPlan = {
  * @param {Object} options - Render options
  * @param {Object} options.user - Mock user object (null for unauthenticated)
  * @param {string} options.theme - 'light' or 'dark'
+ * @param {string} options.themeName - Theme name (e.g., 'cleanSlate', 'classic')
  * @returns {Object} - Render result from @testing-library/react
  */
 export const renderWithProviders = (ui, options = {}) => {
-  const { user = mockUser, theme = "light", ...renderOptions } = options;
+  const {
+    user = mockUser,
+    theme = "light",
+    themeName = "cleanSlate",
+    ...renderOptions
+  } = options;
 
   // Create a wrapper with all providers
   const Wrapper = ({ children }) => (
-    <ThemeProvider initialTheme={theme}>
+    <ThemeProvider initialTheme={theme} initialThemeName={themeName}>
       <UserProvider initialUser={user}>{children}</UserProvider>
     </ThemeProvider>
   );


### PR DESCRIPTION
## Summary

- Adds 6 built-in themes: **Clean Slate** (new default), **Tokyo Nights** (existing, extracted), **Ocean Breeze**, **Forest Floor**, **Lavender Haze**, and **Midnight Ember** — each with light + dark variants
- Adds a **custom theme builder** with color pickers, font pair selection, border radius slider, and glow style toggle for full user personalization
- Refactors `ThemeContext.jsx` from 423 → ~131 lines using a factory-based theme registry pattern
- Updates 8 components to use theme-agnostic MUI palette tokens instead of hardcoded Tokyo Nights colors
- Scopes Tokyo Nights CSS animations/effects under `.theme-tokyo-nights` class selector
- Adds **ThemeSelector** in Account Preferences page with visual preview swatches
- Syncs theme preferences to Firebase for authenticated users (with 1s debounce)
- Migrates existing users' localStorage `theme` key to new `themePrefs` format automatically

## Architecture

Each theme is a factory function `(isDark) => themeConfig` registered in `src/shared/context/themes/index.js`. ThemeContext resolves the active factory via the registry and calls `createTheme()` with `useMemo`. Themes define a `custom` namespace (`theme.custom.macroColors`, `theme.custom.glowStyle`, etc.) that components read for theme-specific styling. A `ThemeSync` component bridges the ThemeProvider/UserProvider hierarchy to persist preferences to Firebase.

## Test plan

- [x] Build passes (`npm run build`)
- [x] Lint clean (`npm run lint`)
- [x] 86 tests passing (same baseline as main)
- [x] Manual browser testing: verified all 6 built-in themes (light + dark), custom theme editor, theme persistence, and dark mode toggle
- [ ] Verify theme persistence across page reloads
- [ ] Verify Firebase sync for authenticated users

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>